### PR TITLE
Fix unified polygon initialization and degradation handling

### DIFF
--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -2271,6 +2271,7 @@ this mask will have smb calculated over the entire global land surface
 
 <!-- NGEE Arctic Options -->
 <use_polygonal_tundra>.false.</use_polygonal_tundra>;
+<prohibit_subsidence>.false.</prohibit_subsidence>;
 <use_arctic_init>.false.</use_arctic_init>;
 
 </namelist_defaults>

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -2271,6 +2271,7 @@ this mask will have smb calculated over the entire global land surface
 
 <!-- NGEE Arctic Options -->
 <use_polygonal_tundra>.false.</use_polygonal_tundra>;
+<uniform_polygonal_tundra>.false.</uniform_polygonal_tundra>;
 <prohibit_subsidence>.false.</prohibit_subsidence>;
 <use_arctic_init>.false.</use_arctic_init>;
 

--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -2244,16 +2244,6 @@ default: 0
 </entry>
 
 <!-- ========================================================================================  -->
-<!-- NGEE Arctic Options                                                                       -->
-<!-- ========================================================================================  -->
-
-<entry id="use_arctic_init" type="logical" category="default_settings"
-	group="elm_inparm" value=".false.">
-Cold-start initialization conditions in tundra start saturated and frozen.
-<default>Default: .false.</default>
-</entry>
-
-<!-- ========================================================================================  -->
 <!-- Namelist options for soil erosion model                                                   -->
 <!-- ========================================================================================  -->
 
@@ -2322,6 +2312,18 @@ not be called.
 <entry id="use_polygonal_tundra" type="logical" category="default_settings"
 	group="elm_inparm" value=".false.">
 Use polygonal tundra parameterizations for ice wedge polygon microtopography and inindation fraction
+<default>Default: .false.</default>
+</entry>
+
+<entry id="prohibit_subsidence" type="logical" category="default_settings"
+       group="elm_inparm" value=".false.">
+Prohibit microtopographic changes associated with subsidence in ice wedge polygons
+<default>Default: .false.</default>
+</entry>
+
+<entry id="use_arctic_init" type="logical" category="default_settings"
+	group="elm_inparm" value=".false.">
+Cold-start initialization conditions in tundra start saturated and frozen.
 <default>Default: .false.</default>
 </entry>
 

--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -2315,6 +2315,12 @@ Use polygonal tundra parameterizations for ice wedge polygon microtopography and
 <default>Default: .false.</default>
 </entry>
 
+<entry id="unified_polygonal_tundra" type="logical" category="default_settings"
+	group="elm_inparm" value=".false.">
+Temporary - use the new unified polygonal tundra parameterization.
+<default>Default: .false.</default>
+</entry>
+
 <entry id="prohibit_subsidence" type="logical" category="default_settings"
        group="elm_inparm" value=".false.">
 Prohibit microtopographic changes associated with subsidence in ice wedge polygons

--- a/components/elm/src/biogeochem/CH4Mod.F90
+++ b/components/elm/src/biogeochem/CH4Mod.F90
@@ -1370,6 +1370,7 @@ contains
 
     associate(                                                                 &
          dz                   =>   col_pp%dz                                    , & ! Input:  [real(r8) (:,:) ]  layer thickness (m)  (-nlevsno+1:nlevsoi)
+         volrat               =>   col_pp%volrat                                ,  & ! RPF - temp debugging input
          zi                   =>   col_pp%zi                                    , & ! Input:  [real(r8) (:,:) ]  interface level below a "z" level (m)
          z                    =>   col_pp%z                                     , & ! Input:  [real(r8) (:,:) ]  layer depth (m) (-nlevsno+1:nlevsoi)
 
@@ -1550,7 +1551,7 @@ contains
                conc_ch4_sat(c,j) = (fsat_bef(c)*conc_ch4_sat(c,j) + dfsat*conc_ch4_unsat(c,j)) / finundated(c)
             else if (fsat_bef(c) /= spval .and. finundated(c) < fsat_bef(c)) then
                ch4_dfsat_flux(c) = ch4_dfsat_flux(c) + (fsat_bef(c) - finundated(c))*(conc_ch4_sat(c,j) - conc_ch4_unsat(c,j)) * &
-                    dz(c,j) / dtime * catomw / 1000._r8 ! mol --> kg
+                    dz(c,j)*volrat(c,j) / dtime * catomw / 1000._r8 ! mol --> kg
             end if
          end do
       end do
@@ -1585,6 +1586,7 @@ contains
                   else if (veg_pp%wtcol(p) < 0.99_r8) then
                      rootfraction(p,j) = spval
                   else
+                     ! RPF non vegetated, don't think this needs volrat
                      rootfraction(p,j) = dz(c,j) / zi(c,nlevsoi)   ! Set equal to uniform distribution
                   end if
                end do
@@ -1606,6 +1608,7 @@ contains
          do j=1, nlevsoi
             do fc = 1, num_soilc
                c = filter_soilc(fc)
+               ! RPF - same logic as above, no volrat needed?
                if (.not. col_pp%active(c)) rootfr_col(c,j) = dz(c,j) / zi(c,nlevsoi)
             end do
          end do
@@ -1773,11 +1776,12 @@ contains
                ! ch4_oxid_tot and ch4_prod_tot are initialized to zero above
             end if
 
+            ! RPF - need to scale concentrations in oxid/prod variables, so volrat needed
             ch4_oxid_tot(c) = ch4_oxid_tot(c) + (finundated(c)*ch4_oxid_depth_sat(c,j) + &
-                 (1._r8 - finundated(c))*ch4_oxid_depth_unsat(c,j))*dz(c,j) * catomw
+                 (1._r8 - finundated(c))*ch4_oxid_depth_unsat(c,j))*dz(c,j) *volrat(c,j)* catomw
             !Convert from mol to g C
             ch4_prod_tot(c) = ch4_prod_tot(c) + (finundated(c)*ch4_prod_depth_sat(c,j) + &
-                 (1._r8 - finundated(c))*ch4_prod_depth_unsat(c,j))*dz(c,j) * catomw
+                 (1._r8 - finundated(c))*ch4_prod_depth_unsat(c,j))*dz(c,j) *volrat(c,j) * catomw
             !Convert from mol to g C
             if (j == nlevsoi) then
                ! Adjustment to NEE flux to atm. for methane production
@@ -1810,6 +1814,7 @@ contains
                   ch4_surf_flux_tot(c) = totalsat*catomw / 1000._r8
                end if
 
+               ! RPF - lake column, so no volrat.
                ch4_oxid_tot(c) = ch4_oxid_tot(c) + ch4_oxid_depth_sat(c,j)*dz(c,j)*catomw
                ch4_prod_tot(c) = ch4_prod_tot(c) + ch4_prod_depth_sat(c,j)*dz(c,j)*catomw
 
@@ -1858,7 +1863,7 @@ contains
             c = filter_soilc(fc)
 
             totcolch4(c) = totcolch4(c) + &
-                 (finundated(c)*conc_ch4_sat(c,j) + (1._r8-finundated(c))*conc_ch4_unsat(c,j))*dz(c,j)*catomw
+                 (finundated(c)*conc_ch4_sat(c,j) + (1._r8-finundated(c))*conc_ch4_unsat(c,j))*dz(c,j)*volrat(c,j)*catomw
             ! mol CH4 --> g C
 
             if (j == nlevsoi .and. totcolch4_bef(c) /= spval) then ! not first timestep
@@ -1870,6 +1875,8 @@ contains
                        nstep,c,errch4
                   g = col_pp%gridcell(c)
                   write(iulog,*) 'Latdeg,Londeg=',grc_pp%latdeg(g),grc_pp%londeg(g)
+                  write(iulog,*) 'RPF - testing volrat:', volrat(c,:), c
+                  write(iulog,*) 'terms of CH4 balance:', totcolch4(c), totcolch4_bef(c), ch4_prod_tot(c), ch4_oxid_tot(c), ch4_surf_flux_tot(c)
                   call endrun(msg=' ERROR: Methane conservation error'//errMsg(__FILE__, __LINE__))
                end if
             end if
@@ -1879,6 +1886,7 @@ contains
             do fc = 1, num_lakec
                c = filter_lakec(fc)
 
+               ! RPF - lakes so no scaling
                totcolch4(c) = totcolch4(c) + conc_ch4_sat(c,j)*dz(c,j)*catomw ! mol CH4 --> g C
 
                if (j == nlevsoi .and. totcolch4_bef(c) /= spval) then ! not first timestep
@@ -1993,6 +2001,7 @@ contains
     associate(                                                     &
          wtcol          =>    veg_pp%wtcol                          , & ! Input:  [real(r8) (:)    ]  weight (relative to column)
          dz             =>    col_pp%dz                             , & ! Input:  [real(r8) (:,:)  ]  layer thickness (m)  (-nlevsno+1:nlevsoi)
+         volrat         =>    col_pp%volrat                         , & ! Input:  [real(r8) (:,:)  ]  volume ratio for compressing layer due to excess ice melt (1:nlevgrnd)
          z              =>    col_pp%z                              , & ! Input:  [real(r8) (:,:)  ]  layer depth (m) (-nlevsno+1:nlevsoi)
          zi             =>    col_pp%zi                             , & ! Input:  [real(r8) (:,:)  ]  interface level below a "z" level (m)
 
@@ -2136,6 +2145,7 @@ contains
             if (t_soisno(c,j) <= tfrz .and. (nlevdecomp == 1 .or. lake)) base_decomp = 0._r8
 
             ! depth dependence of production either from rootfr or decomp model
+            ! RPF - I don't think either of these need to be scaled, since they are not molar concentrations
             if (.not. lake) then ! use default rootfr, averaged to the column level in the ch4 driver, or vert HR
                if (nlevdecomp == 1) then ! not VERTSOILC
                   if (j <= nlev_soildecomp_standard) then  ! Top 5 levels are also used in the CLM code for establishing temperature
@@ -2233,7 +2243,7 @@ contains
             ! Add root respiration
             if (.not. lake) then
                !o2_decomp_depth(c,j) = o2_decomp_depth(c,j) + col_rr(c)*rootfr(c,j)/catomw/dz(c,j) ! mol/m^3/s
-               o2_decomp_depth(c,j) = o2_decomp_depth(c,j) + rr_vr(c,j)/catomw/dz(c,j) ! mol/m^3/s
+               o2_decomp_depth(c,j) = o2_decomp_depth(c,j) + rr_vr(c,j)/catomw/(dz(c,j)*volrat(c,j)) ! mol/m^3/s - RPF
                ! g C/m2/s ! gC/mol O2 ! m
             end if
 
@@ -2246,7 +2256,7 @@ contains
             if (j  >  jwt(c)) then ! Below the water table so anaerobic CH4 production can occur
                ! partition decomposition to layer
                ! turn into per volume-total by dz
-               ch4_prod_depth(c,j) = f_ch4_adj * base_decomp * partition_z / dz (c,j)! [mol/m3-total/s]
+               ch4_prod_depth(c,j) = f_ch4_adj * base_decomp * partition_z / dz (c,j)! [mol/m3-total/s] - RPF not sure about this one! might need to be scaled.
             else ! Above the WT
                if (anoxicmicrosites) then
                   ch4_prod_depth(c,j) = f_ch4_adj * base_decomp * partition_z / dz (c,j) &
@@ -2491,6 +2501,7 @@ contains
     associate(                                                     &
          z             =>    col_pp%z                               , & ! Input:  [real(r8) (:,:)  ]  layer depth (m) (-nlevsno+1:nlevsoi)
          dz            =>    col_pp%dz                              , & ! Input:  [real(r8) (:,:)  ]  layer thickness (m)  (-nlevsno+1:nlevsoi)
+         volrat        =>    col_pp%volrat                          , & ! Input:  [real(r8) (:,:)  ]  volume ratio accounting for layer compression due to excess ice melt (1:nlevgrnd)
          wtcol         =>    veg_pp%wtcol                           , & ! Input:  [real(r8) (:)    ]  weight (relative to column)
 
          elai          =>    canopystate_vars%elai_patch         , & ! Input:  [real(r8) (:)    ]  one-sided leaf area index with burying by snow
@@ -2603,7 +2614,7 @@ contains
                  annsum_npp_ptr, annavg_agnpp_ptr, annavg_bgnpp_ptr, &
                  elai(p), frootc_ptr, poros_tiller, rootfr_vr(1:nlevsoi), &
                  grnd_ch4_cond(p), conc_o2(c,1:nlevsoi), c_atm(g,1:2), &
-                 z(c,1:nlevsoi), dz(c,1:nlevsoi), sat, & 
+                 z(c,1:nlevsoi), dz(c,1:nlevsoi), volrat(c,1:nlevsoi), sat, & 
                  tranloss(1:nlevsoi), &    ! Out
                  aere(1:nlevsoi), &         ! Out
                  oxaere(1:nlevsoi))         ! Out
@@ -2647,6 +2658,7 @@ contains
                     c_atm,            &
                     z,                &
                     dz,               &
+                    volrat,           &
                     sat,              &
                     tranloss,         & ! Out
                     aere,             & ! Out
@@ -2678,6 +2690,7 @@ contains
     real(r8), intent(in) :: c_atm(:)
     real(r8), intent(in) :: z(:)
     real(r8), intent(in) :: dz(:)
+    real(r8), intent(in) :: volrat(:)
     integer,  intent(in) :: sat
 
     ! Arguments (out)
@@ -2712,7 +2725,8 @@ contains
           k_h_cc = t_soisno(j) / k_h_inv * rgasLatm
           conc_ch4_wat = conc_ch4(j) / ( (watsat(j)-h2osoi_vol_min)/k_h_cc + h2osoi_vol_min)
 
-          tranloss(j) = conc_ch4_wat * rootr(j)*qflx_tran_veg / dz(j) / 1000._r8
+          ! RPF - think it is needed here.
+          tranloss(j) = conc_ch4_wat * rootr(j)*qflx_tran_veg / (dz(j)*volrat(j)) / 1000._r8
           ! mol/m3/s    mol/m3                                   mm / s         m           mm/m
           ! Use rootr here for effective per-layer transpiration, which may not be the same as rootfr
           tranloss(j) = max(tranloss(j), 0._r8) ! in case transpiration is pathological
@@ -2765,7 +2779,8 @@ contains
           ! Add in boundary layer resistance
           aerecond = 1._r8 / (1._r8/(aerecond+smallnumber) + 1._r8/(grnd_ch4_cond+smallnumber))
 
-          aere(j) = aerecond * (conc_ch4(j)/watsat(j)/k_h_cc - c_atm(1)) / dz(j) ![mol/m3-total/s]
+          !RPF - both aere and oxaere I think need scaling
+          aere(j) = aerecond * (conc_ch4(j)/watsat(j)/k_h_cc - c_atm(1)) / (volrat(j)*dz(j)) ![mol/m3-total/s]
           !ZS: Added watsat & Henry's const.
           aere(j) = max(aere(j), 0._r8) ! prevent backwards diffusion
 
@@ -2775,7 +2790,7 @@ contains
           oxdiffus = diffus_aere * d_con_g(2,1) / d_con_g(1,1) ! adjust for O2:CH4 molecular diffusion
           aerecond = area_tiller * rootfr(j) * oxdiffus / (z(j)*CH4ParamsInst%rob)
           aerecond = 1._r8 / (1._r8/(aerecond+smallnumber) + 1._r8/(grnd_ch4_cond+smallnumber))
-          oxaere(j) = -aerecond *(conc_o2(j)/watsat(j)/k_h_cc - c_atm(2)) / dz(j) ![mol/m3-total/s]
+          oxaere(j) = -aerecond *(conc_o2(j)/watsat(j)/k_h_cc - c_atm(2)) / (volrat(j)*dz(j)) ![mol/m3-total/s]
           oxaere(j) = max(oxaere(j), 0._r8)
           ! Diffusion in is positive; prevent backwards diffusion
           if ( .not. use_aereoxid_prog ) then ! fixed aere oxid proportion; will be done in ch4_tran
@@ -2846,7 +2861,6 @@ contains
 
     associate(                                                      &
          z            =>    col_pp%z                              , & ! Input:  [real(r8) (:,:) ]  soil layer depth (m)
-         dz           =>    col_pp%dz                             , & ! Input:  [real(r8) (:,:) ]  layer thickness (m)  (-nlevsno+1:nlevsoi)
          zi           =>    col_pp%zi                             , & ! Input:  [real(r8) (:,:) ]  interface level below a "z" level (m)
          lakedepth    =>    col_pp%lakedepth                      , & ! Input:  [real(r8) (:)   ]  column lake depth (m)
          forc_pbot    =>    top_as%pbot                           , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)
@@ -3036,6 +3050,7 @@ contains
     associate(                                                 &
          z             =>    col_pp%z                           , & ! Input:  [real(r8) (:,:) ]  soil layer depth (m)
          dz            =>    col_pp%dz                          , & ! Input:  [real(r8) (:,:) ]  layer thickness (m)  (-nlevsno+1:nlevsoi)
+         volrat        =>    col_pp%volrat                      , & ! Input:  [real(r8) (:,:) ]  volume scaling due to deformation from excess ice melt
          zi            =>    col_pp%zi                          , & ! Input:  [real(r8) (:,:) ]  interface level below a "z" level (m)
          snl           =>    col_pp%snl                         , & ! Input:  [integer  (:)   ]  negative of number of snow layers
 
@@ -3052,6 +3067,7 @@ contains
          h2osoi_vol    =>    col_ws%h2osoi_vol  , & ! Input:  [real(r8) (:,:) ]  volumetric soil water (0<=h2osoi_vol<=watsat) [m3/m3]
          h2osoi_liq    =>    col_ws%h2osoi_liq  , & ! Input:  [real(r8) (:,:) ]  liquid water (kg/m2) [for snow & soil layers]
          h2osoi_ice    =>    col_ws%h2osoi_ice  , & ! Input:  [real(r8) (:,:) ]  ice lens (kg/m2) [for snow & soil layers]
+         excess_ice    =>    col_ws%excess_ice  , & ! Input:  [real(r8) (:,:) ]  excess ice (kg/m2) for soil layers only
          h2osno        =>    col_ws%h2osno      , & ! Input:  [real(r8) (:)   ]  snow water (mm H2O)
          h2osfc        =>    col_ws%h2osfc      , & ! Input:  [real(r8) (:)   ]  surface water (mm)
 
@@ -3176,7 +3192,7 @@ contains
          do fc = 1, num_methc
             c = filter_methc (fc)
             if (j == 1) ch4_ebul_total(c) = 0._r8
-            ch4_ebul_total(c) = ch4_ebul_total(c) + ch4_ebul_depth(c,j) * dz(c,j)
+            ch4_ebul_total(c) = ch4_ebul_total(c) + ch4_ebul_depth(c,j) * dz(c,j) * volrat(c,j) ! RPF
          enddo
       enddo
 
@@ -3261,7 +3277,7 @@ contains
          do fc = 1, num_methc
             c = filter_methc (fc)
             if (j==1) ch4_surf_aere(c) = 0._r8
-            ch4_surf_aere(c) = ch4_surf_aere(c) + ch4_aere_depth(c,j) * dz(c,j)
+            ch4_surf_aere(c) = ch4_surf_aere(c) + ch4_aere_depth(c,j) * dz(c,j) * volrat(c,j)
          enddo
       enddo
 
@@ -3269,7 +3285,7 @@ contains
       do fc = 1, num_methc
          c = filter_methc(fc)
          if (jwt(c) /= 0) then
-            source(c,jwt(c),1) = source(c,jwt(c),1) + ch4_ebul_total(c)/dz(c,jwt(c))
+            source(c,jwt(c),1) = source(c,jwt(c),1) + ch4_ebul_total(c)/(dz(c,jwt(c))*volrat(c,jwt(c)))
          endif
       enddo ! fc
 
@@ -3285,8 +3301,15 @@ contains
             else
                h2osoi_vol_min(c,j) = min(watsat(c,j), h2osoi_vol(c,j))
                if (ch4frzout) then
-                  liqfrac(c,j) = max(0.05_r8, (h2osoi_liq(c,j)/denh2o+smallnumber)/ &
+                  if (j >= 1) then
+                     ! RPF - probably need to adjust liqfrac for excess ice
+                     liqfrac(c,j) = max(0.05_r8, (h2osoi_liq(c,j)/denh2o+smallnumber)/ &
+                       (h2osoi_liq(c,j)/denh2o+(h2osoi_ice(c,j)+excess_ice(c,j))/denice+smallnumber))
+                  else 
+                     ! RPF - probably need to adjust liqfrac for excess ice
+                     liqfrac(c,j) = max(0.05_r8, (h2osoi_liq(c,j)/denh2o+smallnumber)/ &
                        (h2osoi_liq(c,j)/denh2o+h2osoi_ice(c,j)/denice+smallnumber))
+                  endif
                else
                   liqfrac(c,j) = 1._r8
                end if
@@ -3325,7 +3348,7 @@ contains
                ! Add snow resistance
                if (j >= snl(c) + 1) then
                   t_soisno_c = t_soisno(c,j) - tfrz
-                  icefrac = h2osoi_ice(c,j)/denice/dz(c,j)
+                  icefrac = h2osoi_ice(c,j)/denice/dz(c,j) ! RPF - this is snow, so no dz scaling
                   waterfrac = h2osoi_liq(c,j)/denh2o/dz(c,j)
                   airfrac = max(1._r8 - icefrac - waterfrac, 0._r8)
                   ! Calculate snow diffusivity
@@ -3428,6 +3451,7 @@ contains
             do fc = 1, num_methc
                c = filter_methc (fc)
 
+               ! RPF - these should use current dz, no scaling
                ! Set up coefficients for tridiagonal solver.
                if (j == 1 .and. j /= jwt(c) .and. j /= jwt(c)+1) then
                   dm1_zm1(c,j) = 1._r8/(1._r8/spec_grnd_cond(c,s)+dz(c,j)/(diffus(c,j)*2._r8))
@@ -3584,7 +3608,7 @@ contains
                   c = filter_methc (fc)
 
                   if (conc_ch4_rel(c,j) < 0._r8) then
-                     deficit = - conc_ch4_rel(c,j)*epsilon_t(c,j,1)*dz(c,j)  ! Mol/m^2 added
+                     deficit = - conc_ch4_rel(c,j)*epsilon_t(c,j,1)*dz(c,j)*volrat(c,j)  ! Mol/m^2 added
                      if (deficit > 1.e-3_r8 * scale_factor_gasdiff) then
                         if (deficit > 1.e-2_r8) then
                            write(iulog,*)  'Note: sink > source in ch4_tran, sources are changing '// &
@@ -3689,9 +3713,10 @@ contains
             c = filter_methc (fc)
 
             if (j == 1) errch4(c) = 0._r8
-            errch4(c) = errch4(c) + (conc_ch4(c,j) - conc_ch4_bef(c,j))*dz(c,j)
-            errch4(c) = errch4(c) - ch4_prod_depth(c,j)*dz(c,j)*dtime
-            errch4(c) = errch4(c) + ch4_oxid_depth(c,j)*dz(c,j)*dtime
+            ! RPF
+            errch4(c) = errch4(c) + (conc_ch4(c,j) - conc_ch4_bef(c,j))*dz(c,j)*volrat(c,j)
+            errch4(c) = errch4(c) - ch4_prod_depth(c,j)*dz(c,j)*dtime*volrat(c,j)
+            errch4(c) = errch4(c) + ch4_oxid_depth(c,j)*dz(c,j)*dtime*volrat(c,j)
          end do
       end do
 

--- a/components/elm/src/biogeophys/ActiveLayerMod.F90
+++ b/components/elm/src/biogeophys/ActiveLayerMod.F90
@@ -7,7 +7,7 @@ module ActiveLayerMod
   ! !USES:
   use shr_kind_mod    , only : r8 => shr_kind_r8
   use shr_const_mod   , only : SHR_CONST_TKFRZ
-  use elm_varctl      , only : iulog, spinup_state, use_polygonal_tundra, allow_subsidence
+  use elm_varctl      , only : iulog, spinup_state, use_polygonal_tundra, prohibit_subsidence
   use TemperatureType , only : temperature_type
   use CanopyStateType , only : canopystate_type
   use GridcellType    , only : grc_pp       

--- a/components/elm/src/biogeophys/ActiveLayerMod.F90
+++ b/components/elm/src/biogeophys/ActiveLayerMod.F90
@@ -7,7 +7,7 @@ module ActiveLayerMod
   ! !USES:
   use shr_kind_mod    , only : r8 => shr_kind_r8
   use shr_const_mod   , only : SHR_CONST_TKFRZ
-  use elm_varctl      , only : iulog, spinup_state, use_polygonal_tundra
+  use elm_varctl      , only : iulog, spinup_state, use_polygonal_tundra, allow_subsidence
   use TemperatureType , only : temperature_type
   use CanopyStateType , only : canopystate_type
   use GridcellType    , only : grc_pp       
@@ -172,7 +172,7 @@ contains
             endif
          endif
 
-         if (use_polygonal_tundra) then
+         if (use_polygonal_tundra .and. .not. prohibit_subsidence) then
             ! special case for year = 1989. For now it is the assumed baseline year for 
             ! changes in polygonal ground
             if (year .eq. 1989) then

--- a/components/elm/src/biogeophys/ActiveLayerMod.F90
+++ b/components/elm/src/biogeophys/ActiveLayerMod.F90
@@ -89,7 +89,6 @@ contains
          altmax_lastyear_indx =>    canopystate_vars%altmax_lastyear_indx_col , & ! Output:  [integer  (:)   ]  prior year maximum annual depth of thaw
          altmax_1989_indx     =>    canopystate_vars%altmax_1989_indx_col,      & ! Output:  [integer  (:)   ]  index of maximum ALT in 1989
          altmax_ever_indx     =>    canopystate_vars%altmax_ever_indx_col,      & ! Output:  [integer  (:)   ]  maximum thaw depth since initialization
-         excess_ice           =>    col_ws%excess_ice                    ,      & ! Input/output:[real(r8) (:,:)]  depth variable excess ice content in soil column (-)
          rmax                 =>    col_ws%iwp_microrel                  ,      & ! Output:  [real(r8) (:)   ]  ice wedge polygon microtopographic relief (m)
          vexc                 =>    col_ws%iwp_exclvol                   ,      & ! Output:  [real(r8) (:)   ]  ice wedge polygon excluded volume (m)
          ddep                 =>    col_ws%iwp_ddep                      ,      & ! Output:  [real(r8) (:)   ]  ice wedge polygon depression depth (m)

--- a/components/elm/src/biogeophys/ActiveLayerMod.F90
+++ b/components/elm/src/biogeophys/ActiveLayerMod.F90
@@ -93,6 +93,7 @@ contains
          vexc                 =>    col_ws%iwp_exclvol                   ,      & ! Output:  [real(r8) (:)   ]  ice wedge polygon excluded volume (m)
          ddep                 =>    col_ws%iwp_ddep                      ,      & ! Output:  [real(r8) (:)   ]  ice wedge polygon depression depth (m)
          subsidence           =>    col_ws%iwp_subsidence                       & ! Input/output:[real(r8)(:)]  ice wedge polygon subsidence (m)
+         degradation_index    =>    col_ws%degradation_index                    ! Input/output:[real(r8)(:)]  degradation index (0 to 1) based on cumulative subsidence
          )
 
       ! on a set annual timestep, update annual maxima
@@ -267,6 +268,7 @@ contains
              elseif (lun_pp%polygontype(col_pp%landunit(c)) .eq. iunifiedpoly) then
                rmax(c) = 0.4_r8
                vexc(c) = 0.2_r8
+               ! RPF - what to do with the microtopography parameters here?
                ddep(c) = min(0.05_r8, 0.01_r8 + 0.1_r8*subsidence(c))
              else
                !call endrun !<- TODO: needed? Potential way to prevent unintended updating of microtopography

--- a/components/elm/src/biogeophys/ActiveLayerMod.F90
+++ b/components/elm/src/biogeophys/ActiveLayerMod.F90
@@ -92,8 +92,8 @@ contains
          rmax                 =>    col_ws%iwp_microrel                  ,      & ! Output:  [real(r8) (:)   ]  ice wedge polygon microtopographic relief (m)
          vexc                 =>    col_ws%iwp_exclvol                   ,      & ! Output:  [real(r8) (:)   ]  ice wedge polygon excluded volume (m)
          ddep                 =>    col_ws%iwp_ddep                      ,      & ! Output:  [real(r8) (:)   ]  ice wedge polygon depression depth (m)
-         subsidence           =>    col_ws%iwp_subsidence                       & ! Input/output:[real(r8)(:)]  ice wedge polygon subsidence (m)
-         degradation_index    =>    col_ws%degradation_index                    ! Input/output:[real(r8)(:)]  degradation index (0 to 1) based on cumulative subsidence
+         subsidence           =>    col_ws%iwp_subsidence                ,      & ! Input/output:[real(r8)(:)]  ice wedge polygon subsidence (m)
+         degradation_index    =>    col_ws%degradation_index                    & ! Input/output:[real(r8)(:)]  degradation index (0 to 1) based on cumulative subsidence
          )
 
       ! on a set annual timestep, update annual maxima

--- a/components/elm/src/biogeophys/ActiveLayerMod.F90
+++ b/components/elm/src/biogeophys/ActiveLayerMod.F90
@@ -4,6 +4,11 @@ module ActiveLayerMod
   ! !DESCRIPTION:
   ! Module holding routines for calculation of active layer dynamics
   !
+  ! NOTE (Implementation Update): Excess ice melting is now handled thermodynamically
+  ! in PhaseChange_beta (SoilTemperatureMod.F90) rather than geometrically in this module.
+  ! The geometric melting approach and associated frac_melted tracking have been removed.
+  ! Active layer depth calculations remain unchanged for diagnostic purposes.
+  !
   ! !USES:
   use shr_kind_mod    , only : r8 => shr_kind_r8
   use shr_const_mod   , only : SHR_CONST_TKFRZ
@@ -88,8 +93,7 @@ contains
          rmax                 =>    col_ws%iwp_microrel                  ,      & ! Output:  [real(r8) (:)   ]  ice wedge polygon microtopographic relief (m)
          vexc                 =>    col_ws%iwp_exclvol                   ,      & ! Output:  [real(r8) (:)   ]  ice wedge polygon excluded volume (m)
          ddep                 =>    col_ws%iwp_ddep                      ,      & ! Output:  [real(r8) (:)   ]  ice wedge polygon depression depth (m)
-         subsidence           =>    col_ws%iwp_subsidence                ,      & ! Input/output:[real(r8)(:)]  ice wedge polygon subsidence (m)
-         frac_melted          =>    col_ws%frac_melted                          & ! Input/output:[real(r8)(:)]  fraction of layer that has ever melted (-)
+         subsidence           =>    col_ws%iwp_subsidence                       & ! Input/output:[real(r8)(:)]  ice wedge polygon subsidence (m)
          )
 
       ! on a set annual timestep, update annual maxima
@@ -180,62 +184,72 @@ contains
                altmax_1989_indx(c) = altmax_indx(c)
             endif
 
-           ! update subsidence based on change in ALT
-           ! melt_profile stores the amount of excess_ice
-           ! melted in this timestep.
-           ! note that this may cause some unexpected results
-           ! for taliks
-
-           ! initialize melt_profile as zero
-           melt_profile(:) = 0._r8
-
-           do j = nlevgrnd,1,-1 ! note, this will go from bottom to top
-              if (j .gt. k_frz + 1) then ! all layers below k_frz + 1 remain frozen
-                melt_profile(j) = 0.0_r8
-              else if (j .eq. k_frz + 1) then ! first layer below the 'thawed' layer
-                ! need to check to see if the active layer thickness is is actually
-                ! in this layer (and not between the midpoint of j_frz and bottom interface
-                ! or else inferred melt will be negative
-                ! also note: only have ice to melt if alt has never been this deep, otherwise
-                ! ice will continue to be removed each time step the alt remains in this layer
-                if ((alt(c)-zisoi(j-1)) .ge. 0._r8 .and. (alt(c) .eq. altmax_ever(c)) .and. (frac_melted(c,j) .lt. 1._r8)) then
-                  orig_excess = (1._r8/(1._r8-frac_melted(c,j))) * excess_ice(c,j)
-                  old_mfrac = frac_melted(c,j)
-                  ! update frac melted
-                  frac_melted(c,j) = min(max(frac_melted(c,j), (alt(c)-zisoi(j-1))/dzsoi(j)),1._r8)
-                  melt_profile(j) = orig_excess*(frac_melted(c,j) - old_mfrac)
-                  excess_ice(c,j) = excess_ice(c,j) - melt_profile(j)
-                else
-                  melt_profile(j) = 0._r8 ! no melt
-                end if
-              else if (j .eq. k_frz) then
-                if (alt(c) .eq. altmax_ever(c) .and. (frac_melted(c,j) .lt. 1._r8)) then
-                  orig_excess = (1._r8/(1._r8 - frac_melted(c,j))) * excess_ice(c,j)
-                  old_mfrac = frac_melted(c,j)
-                  ! update frac_melted:
-                  frac_melted(c,j) = min(max(frac_melted(c,j), (alt(c)-zsoi(j-1))/dzsoi(j)),1._r8)
-                  ! remove ice, only if alt has never been this deep before:
-                  melt_profile(j) = orig_excess*(frac_melted(c,j) - old_mfrac)
-                  excess_ice(c,j) = excess_ice(c,j) - melt_profile(j)
-                else
-                  melt_profile(j) = 0._r8
-                end if
-              else !
-                 melt_profile(j) = excess_ice(c,j)
-                 ! remove melted excess ice
-                 excess_ice(c,j) = 0._r8
-              end if
-              ! calculate subsidence at this layer:
-              melt_profile(j) = melt_profile(j) * dzsoi(j)
-           end do
-
-           ! subsidence is integral of melt profile:
-           if ((year .ge. 1989) .and. (altmax_ever(c) .ge. altmax_1989(c))) then
-              subsidence(c) = subsidence(c) + sum(melt_profile)
-           end if
-
-           ! limit subsidence to 0.4 m
-           subsidence(c) = min(0.4_r8, subsidence(c))
+           ! ============================================================================
+           ! NOTE: The following geometric melting approach has been replaced by
+           ! thermodynamically-controlled melting in PhaseChange_beta (SoilTemperatureMod.F90).
+           ! Excess ice melting and subsidence are now calculated based on energy balance
+           ! in the phase change routine. This code is retained for reference but is no longer active.
+           ! ============================================================================
+           !
+           ! ! update subsidence based on change in ALT
+           ! ! melt_profile stores the amount of excess_ice
+           ! ! melted in this timestep.
+           ! ! note that this may cause some unexpected results
+           ! ! for taliks
+           !
+           ! ! initialize melt_profile as zero
+           ! melt_profile(:) = 0._r8
+           !
+           ! do j = nlevgrnd,1,-1 ! note, this will go from bottom to top
+           !    if (j .gt. k_frz + 1) then ! all layers below k_frz + 1 remain frozen
+           !      melt_profile(j) = 0.0_r8
+           !    else if (j .eq. k_frz + 1) then ! first layer below the 'thawed' layer
+           !      ! need to check to see if the active layer thickness is is actually
+           !      ! in this layer (and not between the midpoint of j_frz and bottom interface
+           !      ! or else inferred melt will be negative
+           !      ! also note: only have ice to melt if alt has never been this deep, otherwise
+           !      ! ice will continue to be removed each time step the alt remains in this layer
+           !      if ((alt(c)-zisoi(j-1)) .ge. 0._r8 .and. (alt(c) .eq. altmax_ever(c)) .and. (frac_melted(c,j) .lt. 1._r8)) then
+           !        orig_excess = (1._r8/(1._r8-frac_melted(c,j))) * excess_ice(c,j)
+           !        old_mfrac = frac_melted(c,j)
+           !        ! update frac melted
+           !        frac_melted(c,j) = min(max(frac_melted(c,j), (alt(c)-zisoi(j-1))/dzsoi(j)),1._r8)
+           !        melt_profile(j) = orig_excess*(frac_melted(c,j) - old_mfrac)
+           !        excess_ice(c,j) = excess_ice(c,j) - melt_profile(j)
+           !      else
+           !        melt_profile(j) = 0._r8 ! no melt
+           !      end if
+           !    else if (j .eq. k_frz) then
+           !      if (alt(c) .eq. altmax_ever(c) .and. (frac_melted(c,j) .lt. 1._r8)) then
+           !        orig_excess = (1._r8/(1._r8 - frac_melted(c,j))) * excess_ice(c,j)
+           !        old_mfrac = frac_melted(c,j)
+           !        ! update frac_melted:
+           !        frac_melted(c,j) = min(max(frac_melted(c,j), (alt(c)-zsoi(j-1))/dzsoi(j)),1._r8)
+           !        ! remove ice, only if alt has never been this deep before:
+           !        melt_profile(j) = orig_excess*(frac_melted(c,j) - old_mfrac)
+           !        excess_ice(c,j) = excess_ice(c,j) - melt_profile(j)
+           !      else
+           !        melt_profile(j) = 0._r8
+           !      end if
+           !    else !
+           !       melt_profile(j) = excess_ice(c,j)
+           !       ! remove melted excess ice
+           !       excess_ice(c,j) = 0._r8
+           !    end if
+           !    ! calculate subsidence at this layer:
+           !    melt_profile(j) = melt_profile(j) * dzsoi(j)
+           ! end do
+           !
+           ! ! NOTE: Subsidence now calculated in PhaseChange_beta based on actual
+           ! ! excess ice mass change from energy balance
+           ! !
+           ! ! subsidence is integral of melt profile:
+           ! if ((year .ge. 1989) .and. (altmax_ever(c) .ge. altmax_1989(c))) then
+           !    subsidence(c) = subsidence(c) + sum(melt_profile)
+           ! end if
+           !
+           ! ! limit subsidence to 0.4 m
+           ! subsidence(c) = min(0.4_r8, subsidence(c))
 
            ! update ice wedge polygon microtopographic parameters if in polygonal ground
            if (lun_pp%ispolygon(col_pp%landunit(c))) then

--- a/components/elm/src/biogeophys/ActiveLayerMod.F90
+++ b/components/elm/src/biogeophys/ActiveLayerMod.F90
@@ -19,7 +19,7 @@ module ActiveLayerMod
   use ColumnType      , only : col_pp
   use ColumnDataType  , only : col_es, col_ws
   use LandunitType    , only : lun_pp
-  use landunit_varcon , only : ilowcenpoly, iflatcenpoly, ihighcenpoly
+  use landunit_varcon , only : ilowcenpoly, iflatcenpoly, ihighcenpoly, iunifiedpoly
   !
   implicit none
   save
@@ -264,6 +264,10 @@ contains
                rmax(c) = 0.4_r8
                vexc(c) = 0.2_r8
                ddep(c) = 0.05_r8
+             elseif (lun_pp%polygontype(col_pp%landunit(c)) .eq. iunifiedpoly) then
+               rmax(c) = 0.4_r8
+               vexc(c) = 0.2_r8
+               ddep(c) = min(0.05_r8, 0.01_r8 + 0.1_r8*subsidence(c))
              else
                !call endrun !<- TODO: needed? Potential way to prevent unintended updating of microtopography
                ! if polygonal ground is misspecified on surface file.

--- a/components/elm/src/biogeophys/BalanceCheckMod.F90
+++ b/components/elm/src/biogeophys/BalanceCheckMod.F90
@@ -237,6 +237,7 @@ contains
           qflx_to_downhill           =>    col_wf%qflx_to_downhill        , & ! Input:  [real(r8) (:)   ]  sent to downhill topounit
           qflx_h2osfc_surf           =>    col_wf%qflx_h2osfc_surf        , & ! Input:  [real(r8) (:)   ]  surface water runoff (mm/s)
           qflx_snow_melt             =>    col_wf%qflx_snow_melt          , & ! Input:  [real(r8) (:)   ]  snow melt (net)
+          qflx_exice_melt             =>   col_wf%qflx_exice_melt         , & ! Input:  [real(r8) (:,:)   ]  excess ice melt (kg/m2/s)
           qflx_surf                  =>    col_wf%qflx_surf               , & ! Input:  [real(r8) (:)   ]  surface runoff (mm H2O /s)
           qflx_qrgwl                 =>    col_wf%qflx_qrgwl              , & ! Input:  [real(r8) (:)   ]  qflx_surf at glaciers, wetlands, lakes
           qflx_drain                 =>    col_wf%qflx_drain              , & ! Input:  [real(r8) (:)   ]  sub-surface runoff (mm H2O /s)
@@ -436,6 +437,7 @@ contains
              write(iulog,*)'qflx_glcice_melt           = ',qflx_glcice_melt(indexc)
              write(iulog,*)'qflx_glcice_frz            = ',qflx_glcice_frz(indexc)
              write(iulog,*)'qflx_lateral               = ',qflx_lateral(indexc)
+             write(iulog,*)'qflx_exice_melt            = ',qflx_exice_melt(indexc,:)
              write(iulog,*)'total_plant_stored_h2o_col = ',total_plant_stored_h2o_col(indexc)
              write(iulog,*)'qflx_h2orof_drain          = ',qflx_h2orof_drain(indexc)
              write(iulog,*)'qflx_ice_runoff_xs          = ',qflx_ice_runoff_xs(indexc)

--- a/components/elm/src/biogeophys/BalanceCheckMod.F90
+++ b/components/elm/src/biogeophys/BalanceCheckMod.F90
@@ -9,7 +9,7 @@ module BalanceCheckMod
   use shr_log_mod        , only : errMsg => shr_log_errMsg
   use decompMod          , only : bounds_type
   use abortutils         , only : endrun
-  use elm_varctl         , only : iulog, use_var_soil_thick, use_firn_percolation_and_compaction
+  use elm_varctl         , only : iulog, use_var_soil_thick, use_firn_percolation_and_compaction, use_polygonal_tundra
   use elm_varcon         , only : namep, namec
   use GetGlobalValuesMod , only : GetGlobalIndex
   use atm2lndType        , only : atm2lnd_type
@@ -69,7 +69,7 @@ contains
     type(soilhydrology_type)  , intent(inout) :: soilhydrology_vars
     !
     ! !LOCAL VARIABLES:
-    integer :: c, p, f, j, fc                  ! indices
+    integer :: c, p, f, j, fc, l                 ! indices
     real(r8):: h2osoi_vol
     !-----------------------------------------------------------------------
 
@@ -79,6 +79,7 @@ contains
          h2osfc                 =>    col_ws%h2osfc                 , & ! Input:  [real(r8) (:)   ]  surface water (mm)
          h2osno                 =>    col_ws%h2osno                 , & ! Input:  [real(r8) (:)   ]  snow water (mm H2O)
          h2osoi_ice             =>    col_ws%h2osoi_ice             , & ! Input:  [real(r8) (:,:) ]  ice lens (kg/m2)
+         excess_ice             =>    col_ws%excess_ice             , & ! Input:  [real(r8) (:,:) ] excess ice (kg/m2)
          h2osoi_liq             =>    col_ws%h2osoi_liq             , & ! Input:  [real(r8) (:,:) ]  liquid water (kg/m2)
          total_plant_stored_h2o =>    col_ws%total_plant_stored_h2o , & ! Input: [real(r8) (:) dynamic water stored in plants
          zwt                    =>    soilhydrology_vars%zwt_col                 , & ! Input:  [real(r8) (:)   ]  water table depth (m)
@@ -115,10 +116,15 @@ contains
       do j = 1, nlevgrnd
          do f = 1, num_nolakec
             c = filter_nolakec(f)
+            l = col_pp%landunit(c)
             if ((col_pp%itype(c) == icol_sunwall .or. col_pp%itype(c) == icol_shadewall &
                  .or. col_pp%itype(c) == icol_roof) .and. j > nlevurb) then
             else
-               begwb(c) = begwb(c) + h2osoi_ice(c,j) + h2osoi_liq(c,j)
+               if (use_polygonal_tundra .and. lun_pp%ispolygon(l)) then
+                  begwb(c) = begwb(c) + h2osoi_ice(c,j) + h2osoi_liq(c,j) + excess_ice(c,j)
+               else
+                  begwb(c) = begwb(c) + h2osoi_ice(c,j) + h2osoi_liq(c,j)
+               endif 
             end if
          end do
       end do
@@ -237,7 +243,7 @@ contains
           qflx_to_downhill           =>    col_wf%qflx_to_downhill        , & ! Input:  [real(r8) (:)   ]  sent to downhill topounit
           qflx_h2osfc_surf           =>    col_wf%qflx_h2osfc_surf        , & ! Input:  [real(r8) (:)   ]  surface water runoff (mm/s)
           qflx_snow_melt             =>    col_wf%qflx_snow_melt          , & ! Input:  [real(r8) (:)   ]  snow melt (net)
-          qflx_exice_melt             =>   col_wf%qflx_exice_melt         , & ! Input:  [real(r8) (:,:)   ]  excess ice melt (kg/m2/s)
+          qflx_exice_melt             =>   col_wf%qflx_exice_melt         , & ! Input:  [real(r8) (:)   ]  excess ice melt (mm/s)
           qflx_surf                  =>    col_wf%qflx_surf               , & ! Input:  [real(r8) (:)   ]  surface runoff (mm H2O /s)
           qflx_qrgwl                 =>    col_wf%qflx_qrgwl              , & ! Input:  [real(r8) (:)   ]  qflx_surf at glaciers, wetlands, lakes
           qflx_drain                 =>    col_wf%qflx_drain              , & ! Input:  [real(r8) (:)   ]  sub-surface runoff (mm H2O /s)
@@ -415,7 +421,7 @@ contains
           else if (abs(errh2o(indexc)) > 1.e-4_r8 .and. (nstep > 2) ) then
 
              write(iulog,*)'elm model is stopping - error is greater than 1e-4 (mm)'
-             write(iulog,*)'colum number               = ',col_pp%gridcell(indexc)
+             write(iulog,*)'column number              = ',col_pp%gridcell(indexc)
              write(iulog,*)'nstep                      = ',nstep
              write(iulog,*)'errh2o                     = ',errh2o(indexc)
              write(iulog,*)'forc_rain                  = ',forc_rain_col(indexc)
@@ -437,7 +443,7 @@ contains
              write(iulog,*)'qflx_glcice_melt           = ',qflx_glcice_melt(indexc)
              write(iulog,*)'qflx_glcice_frz            = ',qflx_glcice_frz(indexc)
              write(iulog,*)'qflx_lateral               = ',qflx_lateral(indexc)
-             write(iulog,*)'qflx_exice_melt            = ',qflx_exice_melt(indexc,:)
+             write(iulog,*)'qflx_exice_melt            = ',qflx_exice_melt(indexc)
              write(iulog,*)'total_plant_stored_h2o_col = ',total_plant_stored_h2o_col(indexc)
              write(iulog,*)'qflx_h2orof_drain          = ',qflx_h2orof_drain(indexc)
              write(iulog,*)'qflx_ice_runoff_xs          = ',qflx_ice_runoff_xs(indexc)
@@ -813,6 +819,7 @@ contains
          h2osfc                    =>    col_ws%h2osfc                 , & ! Input:  [real(r8) (:)   ]  surface water (mm)
          h2osno                    =>    col_ws%h2osno                 , & ! Input:  [real(r8) (:)   ]  snow water (mm H2O)
          h2osoi_ice                =>    col_ws%h2osoi_ice             , & ! Input:  [real(r8) (:,:) ]  ice lens (kg/m2)
+         excess_ice                =>    col_ws%excess_ice             , & ! Input:  [real(r8) (:,:) ]  excess ice (if using polygonal tundra)
          h2osoi_liq                =>    col_ws%h2osoi_liq             , & ! Input:  [real(r8) (:,:) ]  liquid water (kg/m2)
          total_plant_stored_h2o    =>    col_ws%total_plant_stored_h2o , & ! Input:  [real(r8) (:)   ]  dynamic water stored in plants
          zwt                       =>    soilhydrology_vars%zwt_col                 , & ! Input:  [real(r8) (:)   ]  water table depth (m)

--- a/components/elm/src/biogeophys/EnergyFluxType.F90
+++ b/components/elm/src/biogeophys/EnergyFluxType.F90
@@ -47,6 +47,7 @@ module EnergyFluxType
      real(r8), pointer :: eflx_snomelt_col        (:)   ! col snow melt heat flux (W/m**2)
      real(r8), pointer :: eflx_snomelt_r_col      (:)   ! col rural snow melt heat flux (W/m**2)
      real(r8), pointer :: eflx_snomelt_u_col      (:)   ! col urban snow melt heat flux (W/m**2)
+     real(r8), pointer :: eflx_exice_melt_col     (:)   ! col excess ice melt latent heat flux (W/m**2)
      real(r8), pointer :: eflx_gnet_patch         (:)   ! patch net heat flux into ground  (W/m**2)
      real(r8), pointer :: eflx_grnd_lake_patch    (:)   ! patch net heat flux into lake / snow surface, excluding light transmission (W/m**2)
      real(r8), pointer :: eflx_dynbal_grc         (:)   ! grc dynamic land cover change conversion energy flux (W/m**2)
@@ -210,6 +211,7 @@ contains
     allocate( this%eflx_snomelt_col        (begc:endc))             ; this%eflx_snomelt_col        (:)   = spval 
     allocate( this%eflx_snomelt_r_col      (begc:endc))             ; this%eflx_snomelt_r_col      (:)   = spval 
     allocate( this%eflx_snomelt_u_col      (begc:endc))             ; this%eflx_snomelt_u_col      (:)   = spval 
+    allocate( this%eflx_exice_melt_col     (begc:endc))             ; this%eflx_exice_melt_col     (:)   = spval 
     allocate( this%eflx_fgr12_col          (begc:endc))             ; this%eflx_fgr12_col          (:)   = spval 
     allocate( this%eflx_fgr_col            (begc:endc, 1:nlevgrnd)) ; this%eflx_fgr_col            (:,:) = spval 
     allocate( this%eflx_building_heat_col  (begc:endc))             ; this%eflx_building_heat_col  (:)   = spval 

--- a/components/elm/src/biogeophys/HydrologyDrainageMod.F90
+++ b/components/elm/src/biogeophys/HydrologyDrainageMod.F90
@@ -50,7 +50,7 @@ contains
     use landunit_varcon  , only : istice, istwet, istsoil, istice_mec, istcrop, istice
     use column_varcon    , only : icol_roof, icol_road_imperv, icol_road_perv, icol_sunwall, icol_shadewall
     use elm_varcon       , only : denh2o, denice, secspday, frac_to_downhill
-    use elm_varctl       , only : glc_snow_persistence_max_days, use_vichydro, use_betr
+    use elm_varctl       , only : glc_snow_persistence_max_days, use_vichydro, use_betr, use_polygonal_tundra
     !use domainMod        , only : ldomain
     use elm_varsur         , only : f_surf
     use TopounitType       , only : top_pp
@@ -102,6 +102,7 @@ contains
          begwb                  => col_ws%begwb                  , & ! Input:  [real(r8) (:)   ]  water mass begining of the time step
          endwb                  => col_ws%endwb                  , & ! Output: [real(r8) (:)   ]  water mass end of the time step
          h2osoi_ice             => col_ws%h2osoi_ice             , & ! Output: [real(r8) (:,:) ]  ice lens (kg/m2)
+         excess_ice             => col_ws%excess_ice             , & ! Output? RPF [real(r8) (:,:) ] excess ice (kg/m2)
          h2osoi_liq             => col_ws%h2osoi_liq             , & ! Output: [real(r8) (:,:) ]  liquid water (kg/m2)
          h2osoi_vol             => col_ws%h2osoi_vol             , & ! Output: [real(r8) (:,:) ]  volumetric soil water (0<=h2osoi_vol<=watsat) [m3/m3]
          snow_persistence       => col_ws%snow_persistence       , & ! Output: [real(r8) (:)   ]  counter for length of time snow-covered
@@ -187,13 +188,20 @@ contains
       do j = 1, nlevgrnd
          do fc = 1, num_nolakec
             c = filter_nolakec(fc)
+            l = col_pp%landunit(c)
             if ((ctype(c) == icol_sunwall .or. ctype(c) == icol_shadewall &
                  .or. ctype(c) == icol_roof) .and. j > nlevurb) then
 
             else
-               endwb(c) = endwb(c) + h2osoi_ice(c,j) + h2osoi_liq(c,j)
-               h2osoi_liq_depth_intg(c) = h2osoi_liq_depth_intg(c) + h2osoi_liq(c,j)
-               h2osoi_ice_depth_intg(c) = h2osoi_ice_depth_intg(c) + h2osoi_ice(c,j)
+               if (use_polygonal_tundra .and. lun_pp%ispolygon(l)) then
+                  endwb(c) = endwb(c) + h2osoi_ice(c,j) + h2osoi_liq(c,j) + excess_ice(c,j)
+                  h2osoi_liq_depth_intg(c) = h2osoi_liq_depth_intg(c) + h2osoi_liq(c,j)
+                  h2osoi_ice_depth_intg(c) = h2osoi_ice_depth_intg(c) + h2osoi_ice(c,j) + excess_ice(c,j)
+               else
+                  endwb(c) = endwb(c) + h2osoi_ice(c,j) + h2osoi_liq(c,j)
+                  h2osoi_liq_depth_intg(c) = h2osoi_liq_depth_intg(c) + h2osoi_liq(c,j)
+                  h2osoi_ice_depth_intg(c) = h2osoi_ice_depth_intg(c) + h2osoi_ice(c,j)
+               end if
             end if
          end do
       end do

--- a/components/elm/src/biogeophys/SoilHydrologyMod.F90
+++ b/components/elm/src/biogeophys/SoilHydrologyMod.F90
@@ -421,7 +421,10 @@ contains
           i_0                  =>    soilhydrology_vars%i_0_col              , & ! Input:  [real(r8) (:)   ]  column average soil moisture in top VIC layers (mm)
           h2osfcflag           =>    soilhydrology_vars%h2osfcflag           , & ! Input:  logical
           pc_grid              =>    soilhydrology_vars%pc                   , & ! Input:  [real(r8) (:)   ]  threshold for outflow from surface water storage
-          icefrac              =>    soilhydrology_vars%icefrac_col            & ! Output: [real(r8) (:,:) ]  fraction of ice
+          icefrac              =>    soilhydrology_vars%icefrac_col          , & ! Output: [real(r8) (:,:) ]  fraction of ice
+
+          ! RPF debug, would be helpful to also keep the h2osfc from the previous time step
+          h2osfc_p             =>   col_ws%h2osfc_p                           & ! Input? Really for debugging to see if time aliasing causes spread in IM1 issues
               )
 
 
@@ -442,6 +445,9 @@ contains
           g  = cgridcell(c)
           pc = pc_grid(g)
           
+         ! before doing anything, preserve h2osfc:
+          h2osfc_p(c) = h2osfc(c)
+
           ! partition moisture fluxes between soil and h2osfc
           if (lun_pp%itype(col_pp%landunit(c)) == istsoil .or. lun_pp%itype(col_pp%landunit(c))==istcrop) then
 

--- a/components/elm/src/biogeophys/SoilHydrologyMod.F90
+++ b/components/elm/src/biogeophys/SoilHydrologyMod.F90
@@ -562,7 +562,7 @@ contains
              if (lun_pp%ispolygon(col_pp%landunit(c))) then
                 vdep = (2_r8*iwp_exclvol(c) - iwp_microrel(c)) * (iwp_ddep(c)/iwp_microrel(c))**3_r8 &
                        + (2_r8*iwp_microrel(c) - 3_r8*iwp_exclvol(c)) * (iwp_ddep(c)/iwp_microrel(c))**2_r8
-                phi_eff = min(iwp_subsidence(c), 0.4_r8)  !fix this variable when available to pull from alt calculations
+                phi_eff = min(iwp_subsidence(c), 0.4_r8)  !possibly redundant w/ ActiveLayerMod
                 swc = h2osfc(c)/1000_r8 ! convert to m
                 
                 if (swc >= vdep) then

--- a/components/elm/src/biogeophys/SoilHydrologyMod.F90
+++ b/components/elm/src/biogeophys/SoilHydrologyMod.F90
@@ -304,7 +304,7 @@ contains
      use elm_varcon       , only : denh2o, denice, roverg, wimp, mu, tfrz
      use elm_varcon       , only : pondmx, watmin
      use column_varcon    , only : icol_roof, icol_road_imperv, icol_sunwall, icol_shadewall, icol_road_perv
-     use landunit_varcon  , only : istsoil, istcrop, ilowcenpoly, iflatcenpoly, ihighcenpoly
+     use landunit_varcon  , only : istsoil, istcrop, ilowcenpoly, iunifiedpoly
      use elm_time_manager , only : get_step_size, get_nstep
      use atm2lndType      , only : atm2lnd_type ! land river two way coupling
      use lnd2atmType      , only : lnd2atm_type
@@ -353,6 +353,7 @@ contains
      real(r8) :: vdep                                       ! temporary, ice wedge polygon volumetric depression depth (m)
      real(r8) :: phi_eff                                    ! temporary, polygonal ground effective subsidence (maxes out at 0.4) (m)
      real(r8) :: swc                                        ! temporary, polygonal surface water content in m
+     real(r8) :: a, b, b0, b1
      ! in top VIC layers for runoff calculation
      real(r8) :: rsurf_vic                                  ! temp VIC surface runoff
      real(r8) :: top_moist(bounds%begc:bounds%endc)         ! temporary, soil moisture in top VIC layers
@@ -387,6 +388,7 @@ contains
           iwp_exclvol          =>    col_ws%iwp_exclvol          , & ! Input:  [real(r8) (:)   ]  ice wedge polygon excluded volume (m)
           iwp_ddep             =>    col_ws%iwp_ddep             , & ! Input:  [real(r8) (:)   ]  ice wedge polygon depression depth (m)
           iwp_subsidence       =>    col_ws%iwp_subsidence       , & ! Input:  [real(r8) (:)   ]  ice wedge polygon ground subsidence (m)
+          degradation_index    =>    col_ws%degradation_index    , & ! Input:  [real(r8) (:)   ]  degradation index (0 to 1)
 
           qflx_ev_soil         =>    col_wf%qflx_ev_soil         , & ! Input:  [real(r8) (:)   ]  evaporation flux from soil (W/m**2) [+ to atm]
           qflx_evap_soi        =>    col_wf%qflx_evap_soi        , & ! Input:  [real(r8) (:)   ]  ground surface evaporation rate (mm H2O/s) [+]
@@ -565,7 +567,7 @@ contains
                 endif
              endif
 
-             if (lun_pp%ispolygon(col_pp%landunit(c))) then
+             if (lun_pp%ispolygon(col_pp%landunit(c)) .and. .not. lun_pp%polygontype(col_pp%landunit(c)) == iunifiedpoly) then
                 vdep = (2_r8*iwp_exclvol(c) - iwp_microrel(c)) * (iwp_ddep(c)/iwp_microrel(c))**3_r8 &
                        + (2_r8*iwp_microrel(c) - 3_r8*iwp_exclvol(c)) * (iwp_ddep(c)/iwp_microrel(c))**2_r8
                 phi_eff = min(iwp_subsidence(c), 0.4_r8)  !possibly redundant w/ ActiveLayerMod
@@ -583,7 +585,15 @@ contains
                 else
                    qflx_h2osfc_surf(c) = 0._r8
                 endif
-                
+             else if (lun_pp%polygontype(col_pp%landunit(c)) == iunifiedpoly .and. lun_pp%ispolygon(col_pp%landunit(c)) .and. unified_polygonal_tundra) then
+                  swc = h2osfc(c)/1000_r8 ! convert to m
+                  ! Per SLP 260323: delta can be left out since we're evaluating numerically 
+                  ! rather than determining analytical solution
+                  a = 3.5_r8 + (2._r8 - 3.5_r8) * degradation_index(c)
+                  b0 = 0.014_r8 * meangradz(c) ** (-0.37_r8)
+                  b1 = 0.0017_r8 * meangradz(c) ** (-0.37_r8)
+                  b = b0 + (b1 - b0) * degradation_index(c)
+                  qflx_h2osfc_surf(c) = 0.014_r8 * ((swc/b) ** 0.37_r8) * (0.5_r8 * (1 + (swc/b) ** (1_r8))**((0.4_r8-a)))
              else
                 ! limit runoff to value of storage above S(pc)
                 if(h2osfc(c) >= h2osfc_thresh(c) .and. h2osfcflag/=0) then

--- a/components/elm/src/biogeophys/SoilHydrologyMod.F90
+++ b/components/elm/src/biogeophys/SoilHydrologyMod.F90
@@ -585,7 +585,7 @@ contains
                 else
                    qflx_h2osfc_surf(c) = 0._r8
                 endif
-             else if (lun_pp%polygontype(col_pp%landunit(c)) == iunifiedpoly .and. lun_pp%ispolygon(col_pp%landunit(c)) .and. unified_polygonal_tundra) then
+             else if (lun_pp%polygontype(col_pp%landunit(c)) == iunifiedpoly .and. lun_pp%ispolygon(col_pp%landunit(c))) then
                   swc = h2osfc(c)/1000_r8 ! convert to m
                   ! Per SLP 260323: delta can be left out since we're evaluating numerically 
                   ! rather than determining analytical solution

--- a/components/elm/src/biogeophys/SoilHydrologyMod.F90
+++ b/components/elm/src/biogeophys/SoilHydrologyMod.F90
@@ -9,7 +9,7 @@ module SoilHydrologyMod
   use decompMod         , only : bounds_type
   use elm_varctl        , only : iulog, use_vichydro
   use elm_varctl        , only : use_lnd_rof_two_way, lnd_rof_coupling_nstep
-  use elm_varctl        , only : use_modified_infil
+  use elm_varctl        , only : use_modified_infil, unified_polygonal_tundra
   use elm_varcon        , only : e_ice, denh2o, denice, rpi
   use EnergyFluxType    , only : energyflux_type
   use SoilHydrologyType , only : soilhydrology_type
@@ -589,11 +589,15 @@ contains
                   swc = h2osfc(c)/1000_r8 ! convert to m
                   ! Per SLP 260323: delta can be left out since we're evaluating numerically 
                   ! rather than determining analytical solution
-                  a = 3.5_r8 + (2._r8 - 3.5_r8) * degradation_index(c)
-                  b0 = 0.014_r8 * meangradz(c) ** (-0.37_r8)
-                  b1 = 0.0017_r8 * meangradz(c) ** (-0.37_r8)
-                  b = b0 + (b1 - b0) * degradation_index(c)
-                  qflx_h2osfc_surf(c) = 0.014_r8 * ((swc/b) ** 0.37_r8) * (0.5_r8 * (1 + (swc/b) ** (1_r8))**((0.4_r8-a)))
+                  if (unified_polygonal_tundra) then
+                     a = 3.5_r8 + (2._r8 - 3.5_r8) * degradation_index(c)
+                     b0 = 0.014_r8 * meangradz(c) ** (-0.37_r8)
+                     b1 = 0.0017_r8 * meangradz(c) ** (-0.37_r8)
+                     b = b0 + (b1 - b0) * degradation_index(c)
+                     qflx_h2osfc_surf(c) = 0.014_r8 * ((swc/b) ** 0.37_r8) * (0.5_r8 * (1 + (swc/b) ** (1_r8))**((0.4_r8-a)))
+                  else
+                     qflx_h2osfc_surf(c) = 0._r8
+                  endif
              else
                 ! limit runoff to value of storage above S(pc)
                 if(h2osfc(c) >= h2osfc_thresh(c) .and. h2osfcflag/=0) then

--- a/components/elm/src/biogeophys/SoilTemperatureMod.F90
+++ b/components/elm/src/biogeophys/SoilTemperatureMod.F90
@@ -1399,7 +1399,8 @@ contains
          qflx_glcice_melt_diag =>    col_wf%qflx_glcice_melt_diag , & ! Output: [real(r8) (:)   ] ice melt (positive definite) (mm H2O/s)
          qflx_snomelt     =>    col_wf%qflx_snomelt     , & ! Output: [real(r8) (:)   ] snow melt (mm H2O /s)
          qflx_snomelt_lyr     =>    col_wf%qflx_snomelt_lyr     , & ! Output: [real(r8) (:)   ] snow melt (mm H2O /s)
-         qflx_exice_melt  =>    col_wf%qflx_exice_melt  , & ! Output: [real(r8) (:,:) ] excess ice melt rate (kg/m2/s)
+         qflx_exice_melt_lyr  =>    col_wf%qflx_exice_melt_lyr  , & ! Output: [real(r8) (:,:) ] excess ice melt rate (kg/m2/s)
+         qflx_exice_melt  =>    col_wf%qflx_exice_melt,    & ! Output: [real(r8) (:) ] integrated excess ice melt (mm H2O/s)
 
          eflx_snomelt     =>    col_ef%eflx_snomelt    , & ! Output: [real(r8) (:)   ] snow melt heat flux (W/m**2)
          eflx_snomelt_r   =>    col_ef%eflx_snomelt_r  , & ! Output: [real(r8) (:)   ] rural snow melt heat flux (W/m**2)
@@ -1427,8 +1428,8 @@ contains
          qflx_glcice_melt(c) = 0._r8
          qflx_glcice_melt_diag(c) = 0._r8
          qflx_snow_melt(c) = 0._r8
-         qflx_exice_melt(c,:) = 0._r8
-         eflx_exice_melt(c) = 0._r8
+         qflx_exice_melt_lyr(c,:) = 0._r8
+         qflx_exice_melt(c) = 0._r8
       end do
 
       do j = -nlevsno+1,nlevgrnd       ! all layers
@@ -1625,7 +1626,7 @@ contains
                         ! For soil layers with excess ice, use surplus heat to melt excess ice
                         if (j >= 1 .and. use_polygonal_tundra) then
                            l = col_pp%landunit(c)
-                           if (lun_pp%ispolygon(l) .and. excess_ice(c,j) > 0._r8 .and. xm2(c,j) > 0._r8) then
+                           if (lun_pp%ispolygon(l) .and. excess_ice(c,j) > 0._r8 .and. xm2(c,j) > 0._r8) then 
                               excess_ice(c,j) = max(0._r8, wexice0(c,j) - xm2(c,j))
                            end if
                            
@@ -1674,7 +1675,7 @@ contains
 
                      ! Update liquid water including melted excess ice
                      h2osoi_liq(c,j) = max(0._r8,wmass0(c,j)-h2osoi_ice(c,j)-excess_ice(c,j))
-
+                     
                      if (abs(heatr) > 0._r8) then
                         if (j == snl(c)+1) then
 
@@ -1709,8 +1710,9 @@ contains
                            l = col_pp%landunit(c)
                            if (lun_pp%ispolygon(l)) then
                               ! Excess ice melt flux (kg/m2/s)
-                              qflx_exice_melt(c,j) = max(0._r8, (wexice0(c,j) - excess_ice(c,j)) / dtime)
-                              
+                              qflx_exice_melt_lyr(c,j) = max(0._r8, (wexice0(c,j) - excess_ice(c,j)) / dtime)
+                              qflx_exice_melt(c) = qflx_exice_melt(c) + max(0._r8, (wexice0(c,j) - excess_ice(c,j)) / dtime)
+
                               ! Total latent heat flux (pore ice + excess ice)
                               xmf(c) = xmf(c) + hfus*(wice0(c,j) - h2osoi_ice(c,j))/dtime + &
                                                 hfus*(wexice0(c,j) - excess_ice(c,j))/dtime
@@ -1801,7 +1803,7 @@ contains
             if (lun_pp%ispolygon(l)) then
                ! Sum across all layers for energy flux
                do j = 1, nlevgrnd
-                  eflx_exice_melt(c) = eflx_exice_melt(c) + qflx_exice_melt(c,j) * hfus
+                  eflx_exice_melt(c) = eflx_exice_melt(c) + qflx_exice_melt_lyr(c,j) * hfus
                   
                   ! Update cumulative subsidence since 1989
                   ! (volume change = mass / density)

--- a/components/elm/src/biogeophys/SoilTemperatureMod.F90
+++ b/components/elm/src/biogeophys/SoilTemperatureMod.F90
@@ -1335,7 +1335,7 @@ contains
     use elm_varpar       , only : nlevsno, nlevgrnd,nlevurb
     use elm_varctl       , only : iulog, use_polygonal_tundra
     use elm_varcon       , only : tfrz, hfus, grav, denice
-    use clm_time_manager , only : get_curr_date
+    use elm_time_manager , only : get_curr_date
     use column_varcon    , only : icol_roof, icol_sunwall, icol_shadewall, icol_road_perv
     use landunit_varcon  , only : istsoil, istcrop, istice_mec,istice
     !
@@ -1399,12 +1399,12 @@ contains
          qflx_glcice_melt_diag =>    col_wf%qflx_glcice_melt_diag , & ! Output: [real(r8) (:)   ] ice melt (positive definite) (mm H2O/s)
          qflx_snomelt     =>    col_wf%qflx_snomelt     , & ! Output: [real(r8) (:)   ] snow melt (mm H2O /s)
          qflx_snomelt_lyr     =>    col_wf%qflx_snomelt_lyr     , & ! Output: [real(r8) (:)   ] snow melt (mm H2O /s)
-         qflx_exice_melt  =>    col_wf%qflx_exice_melt_col  , & ! Output: [real(r8) (:,:) ] excess ice melt rate (kg/m2/s)
+         qflx_exice_melt  =>    col_wf%qflx_exice_melt  , & ! Output: [real(r8) (:,:) ] excess ice melt rate (kg/m2/s)
 
          eflx_snomelt     =>    col_ef%eflx_snomelt    , & ! Output: [real(r8) (:)   ] snow melt heat flux (W/m**2)
          eflx_snomelt_r   =>    col_ef%eflx_snomelt_r  , & ! Output: [real(r8) (:)   ] rural snow melt heat flux (W/m**2)
          eflx_snomelt_u   =>    col_ef%eflx_snomelt_u  , & ! Output: [real(r8) (:)   ] urban snow melt heat flux (W/m**2)
-         eflx_exice_melt  =>    col_ef%eflx_exice_melt_col  , & ! Output: [real(r8) (:)   ] excess ice latent heat (W/m2)
+         eflx_exice_melt  =>    col_ef%eflx_exice_melt  , & ! Output: [real(r8) (:)   ] excess ice latent heat (W/m2)
 
          xmf              =>    col_ef%xmf            , &
          fact             =>    col_es%fact                         , &

--- a/components/elm/src/biogeophys/SoilTemperatureMod.F90
+++ b/components/elm/src/biogeophys/SoilTemperatureMod.F90
@@ -1338,6 +1338,7 @@ contains
     use elm_time_manager , only : get_curr_date
     use column_varcon    , only : icol_roof, icol_sunwall, icol_shadewall, icol_road_perv
     use landunit_varcon  , only : istsoil, istcrop, istice_mec,istice
+    use ExcessIceMod     , only : recompute_layer_geometry
     !
     ! !ARGUMENTS:
     type(bounds_type)      , intent(in)    :: bounds
@@ -1815,6 +1816,17 @@ contains
             end if
          end if
       end do
+
+      ! Update layer geometry for polygon tundra columns after excess ice change
+      if (use_polygonal_tundra) then
+         do fc = 1, num_nolakec
+            c = filter_nolakec(fc)
+            l = col_pp%landunit(c)
+            if (lun_pp%ispolygon(l)) then
+               call recompute_layer_geometry(c)
+            end if
+         end do
+      end if
 
       call t_stop_lnd( event )
       do j = -nlevsno+1,0

--- a/components/elm/src/biogeophys/SoilTemperatureMod.F90
+++ b/components/elm/src/biogeophys/SoilTemperatureMod.F90
@@ -1390,6 +1390,7 @@ contains
          h2osoi_ice       =>    col_ws%h2osoi_ice      , & ! Output: [real(r8) (:,:) ] ice lens (kg/m2) (new)
          excess_ice       =>    col_ws%excess_ice      , & ! InOut:  [real(r8) (:,:) ] excess ice (kg/m2)
          iwp_subsidence   =>    col_ws%iwp_subsidence  , & ! InOut:  [real(r8) (:)   ] cumulative subsidence (m)
+         degradation_index=>    col_ws%degradation_index, & ! InOut:  [real(r8) (:)   ] degradation index (0 to 1)
 
          qflx_snow_melt   =>    col_wf%qflx_snow_melt   , & ! Output: [real(r8) (:)   ] net snow melt
          qflx_snofrz_lyr  =>    col_wf%qflx_snofrz_lyr  , & ! Output: [real(r8) (:,:) ] snow freezing rate (positive definite) (col,lyr) [kg m-2 s-1]
@@ -1820,8 +1821,11 @@ contains
                   if (year >= 1989 .and. wexice0(c,j) > excess_ice(c,j)) then
                      iwp_subsidence(c) = iwp_subsidence(c) + &
                                          (wexice0(c,j) - excess_ice(c,j)) / denice
+
                   end if
                end do
+               ! update degradation index
+               degradation_index(c) = iwp_subsidence(c) / 0.4_r8
             end if
          end if
       end do

--- a/components/elm/src/biogeophys/SoilTemperatureMod.F90
+++ b/components/elm/src/biogeophys/SoilTemperatureMod.F90
@@ -834,7 +834,7 @@ contains
     use elm_varcon      , only : denh2o, denice, tfrz, tkwat, tkice, tkair, cpice,  cpliq, thk_bedrock
     use landunit_varcon , only : istice, istice_mec, istwet
     use column_varcon   , only : icol_roof, icol_sunwall, icol_shadewall, icol_road_perv, icol_road_imperv
-    use elm_varctl      , only : iulog, use_T_rho_dependent_snowthk
+    use elm_varctl      , only : iulog, use_T_rho_dependent_snowthk, use_polygonal_tundra
     !
     ! !ARGUMENTS:
     type(bounds_type)      , intent(in)    :: bounds
@@ -893,6 +893,7 @@ contains
          h2osno       =>    col_ws%h2osno            , & ! Input:  [real(r8) (:)   ]  snow water (mm H2O)
          h2osoi_liq   =>    col_ws%h2osoi_liq   , & ! Input:  [real(r8) (:,:) ]  liquid water (kg/m2)
          h2osoi_ice   =>    col_ws%h2osoi_ice   , & ! Input:  [real(r8) (:,:) ]  ice lens (kg/m2)
+         excess_ice   =>    col_ws%excess_ice   , & ! Input:  [real(r8) (:,:) ]  excess ice (kg/m2)
          bw           =>    col_ws%bw        , & ! Output: [real(r8) (:,:) ]  partial density of water in the snow pack (ice + liquid) [kg/m3]
 
          tkmg         =>    soilstate_vars%tkmg_col          , & ! Input:  [real(r8) (:,:) ]  thermal conductivity, soil minerals  [W/m-K]
@@ -926,7 +927,13 @@ contains
                     .AND. col_pp%itype(c) /= icol_sunwall .AND. col_pp%itype(c) /= icol_shadewall .AND. &
                     col_pp%itype(c) /= icol_roof) then
 
-                  satw = (h2osoi_liq(c,j)/denh2o + h2osoi_ice(c,j)/denice)/(dz(c,j)*watsat(c,j))
+                  ! Add excess ice to saturation calculation for polygonal tundra
+                  if (use_polygonal_tundra .and. lun_pp%ispolygon(l)) then
+                     satw = (h2osoi_liq(c,j)/denh2o + h2osoi_ice(c,j)/denice + &
+                             excess_ice(c,j)/denice) / (dz(c,j)*watsat(c,j))
+                  else
+                     satw = (h2osoi_liq(c,j)/denh2o + h2osoi_ice(c,j)/denice)/(dz(c,j)*watsat(c,j))
+                  end if
                   satw = min(1._r8, satw)
                   if (satw > .1e-6_r8) then
                      if (t_soisno(c,j) >= tfrz) then       ! Unfrozen soil
@@ -936,6 +943,14 @@ contains
                      end if
                      fl = (h2osoi_liq(c,j)/(denh2o*dz(c,j))) / (h2osoi_liq(c,j)/(denh2o*dz(c,j)) + &
                           h2osoi_ice(c,j)/(denice*dz(c,j)))
+                     
+                     ! Update liquid fraction for polygonal tundra to include excess ice
+                     if (use_polygonal_tundra .and. lun_pp%ispolygon(l)) then
+                        fl = (h2osoi_liq(c,j)/(denh2o*dz(c,j))) / &
+                             (h2osoi_liq(c,j)/(denh2o*dz(c,j)) + &
+                              h2osoi_ice(c,j)/(denice*dz(c,j)) + &
+                              excess_ice(c,j)/(denice*dz(c,j)))
+                     end if
                      dksat = tkmg(c,j)*tkwat**(fl*watsat(c,j))*tkice**((1._r8-fl)*watsat(c,j))
                      thk(c,j) = dke*dksat + (1._r8-dke)*tkdry(c,j)
                   else
@@ -1047,6 +1062,11 @@ contains
                  .AND. col_pp%itype(c) /= icol_sunwall .AND. col_pp%itype(c) /= icol_shadewall .AND. &
                  col_pp%itype(c) /= icol_roof) then
                cv(c,j) = csol(c,j)*(1._r8-watsat(c,j))*dz(c,j) + (h2osoi_ice(c,j)*cpice + h2osoi_liq(c,j)*cpliq)
+               
+               ! Add excess ice heat capacity for soil layers in polygonal tundra
+               if (use_polygonal_tundra .and. lun_pp%ispolygon(l)) then
+                  cv(c,j) = cv(c,j) + excess_ice(c,j)*cpice
+               end if
             else if (lun_pp%itype(l) == istwet) then
                cv(c,j) = (h2osoi_ice(c,j)*cpice + h2osoi_liq(c,j)*cpliq)
                if (j > nlevbed) cv(c,j) = csol(c,j)*dz(c,j)
@@ -1313,8 +1333,9 @@ contains
     ! !USES:
       !$acc routine seq
     use elm_varpar       , only : nlevsno, nlevgrnd,nlevurb
-    use elm_varctl       , only : iulog
-    use elm_varcon       , only : tfrz, hfus, grav
+    use elm_varctl       , only : iulog, use_polygonal_tundra
+    use elm_varcon       , only : tfrz, hfus, grav, denice
+    use clm_time_manager , only : get_curr_date
     use column_varcon    , only : icol_roof, icol_sunwall, icol_shadewall, icol_road_perv
     use landunit_varcon  , only : istsoil, istcrop, istice_mec,istice
     !
@@ -1342,6 +1363,9 @@ contains
     real(r8) :: propor                             !proportionality constant (-)
     real(r8) :: tinc(bounds%begc:bounds%endc,-nlevsno+1:nlevgrnd)  !t(n+1)-t(n) (K)
     real(r8) :: smp                                !frozen water potential (mm)
+    real(r8) :: wexice0(bounds%begc:bounds%endc,-nlevsno+1:nlevgrnd) ! initial excess ice (kg/m2)
+    real(r8) :: xm2(bounds%begc:bounds%endc,-nlevsno+1:nlevgrnd)     ! excess melt for excess ice (kg/m2)
+    integer  :: year, mon, day, sec                ! for subsidence tracking since 1989
     
     character(len=64) :: event 
     !-----------------------------------------------------------------------
@@ -1363,6 +1387,8 @@ contains
          h2osno           =>    col_ws%h2osno          , & ! Output: [real(r8) (:)   ] snow water (mm H2O)
          h2osoi_liq       =>    col_ws%h2osoi_liq      , & ! Output: [real(r8) (:,:) ] liquid water (kg/m2) (new)
          h2osoi_ice       =>    col_ws%h2osoi_ice      , & ! Output: [real(r8) (:,:) ] ice lens (kg/m2) (new)
+         excess_ice       =>    col_ws%excess_ice      , & ! InOut:  [real(r8) (:,:) ] excess ice (kg/m2)
+         iwp_subsidence   =>    col_ws%iwp_subsidence  , & ! InOut:  [real(r8) (:)   ] cumulative subsidence (m)
 
          qflx_snow_melt   =>    col_wf%qflx_snow_melt   , & ! Output: [real(r8) (:)   ] net snow melt
          qflx_snofrz_lyr  =>    col_wf%qflx_snofrz_lyr  , & ! Output: [real(r8) (:,:) ] snow freezing rate (positive definite) (col,lyr) [kg m-2 s-1]
@@ -1373,10 +1399,12 @@ contains
          qflx_glcice_melt_diag =>    col_wf%qflx_glcice_melt_diag , & ! Output: [real(r8) (:)   ] ice melt (positive definite) (mm H2O/s)
          qflx_snomelt     =>    col_wf%qflx_snomelt     , & ! Output: [real(r8) (:)   ] snow melt (mm H2O /s)
          qflx_snomelt_lyr     =>    col_wf%qflx_snomelt_lyr     , & ! Output: [real(r8) (:)   ] snow melt (mm H2O /s)
+         qflx_exice_melt  =>    col_wf%qflx_exice_melt_col  , & ! Output: [real(r8) (:,:) ] excess ice melt rate (kg/m2/s)
 
          eflx_snomelt     =>    col_ef%eflx_snomelt    , & ! Output: [real(r8) (:)   ] snow melt heat flux (W/m**2)
          eflx_snomelt_r   =>    col_ef%eflx_snomelt_r  , & ! Output: [real(r8) (:)   ] rural snow melt heat flux (W/m**2)
          eflx_snomelt_u   =>    col_ef%eflx_snomelt_u  , & ! Output: [real(r8) (:)   ] urban snow melt heat flux (W/m**2)
+         eflx_exice_melt  =>    col_ef%eflx_exice_melt_col  , & ! Output: [real(r8) (:)   ] excess ice latent heat (W/m2)
 
          xmf              =>    col_ef%xmf            , &
          fact             =>    col_es%fact                         , &
@@ -1399,6 +1427,8 @@ contains
          qflx_glcice_melt(c) = 0._r8
          qflx_glcice_melt_diag(c) = 0._r8
          qflx_snow_melt(c) = 0._r8
+         qflx_exice_melt(c,:) = 0._r8
+         eflx_exice_melt(c) = 0._r8
       end do
 
       do j = -nlevsno+1,nlevgrnd       ! all layers
@@ -1410,9 +1440,20 @@ contains
                imelt(c,j) = 0
                hm(c,j) = 0._r8
                xm(c,j) = 0._r8
+               xm2(c,j) = 0._r8
                wice0(c,j) = h2osoi_ice(c,j)
                wliq0(c,j) = h2osoi_liq(c,j)
-               wmass0(c,j) = h2osoi_ice(c,j) + h2osoi_liq(c,j)
+               wexice0(c,j) = 0._r8
+               
+               ! Store initial excess ice for soil layers
+               if (j >= 1 .and. use_polygonal_tundra) then
+                  l = col_pp%landunit(c)
+                  if (lun_pp%ispolygon(l)) then
+                     wexice0(c,j) = excess_ice(c,j)
+                  end if
+               end if
+               
+               wmass0(c,j) = h2osoi_ice(c,j) + h2osoi_liq(c,j) + wexice0(c,j)
             endif   ! end of snow layer if-block
          end do   ! end of column-loop
       enddo   ! end of level-loop
@@ -1574,23 +1615,65 @@ contains
                      endif
 
                      heatr = 0._r8
-                     if (xm(c,j) > 0._r8) then
-                        h2osoi_ice(c,j) = max(0._r8, wice0(c,j)-xm(c,j))
-                        heatr = hm(c,j) - hfus*(wice0(c,j)-h2osoi_ice(c,j))/dtime
-                     else if (xm(c,j) < 0._r8) then
+                     if (xm(c,j) > 0._r8) then  ! Melting
+                        ! First melt pore ice
+                        h2osoi_ice(c,j) = max(0._r8, wice0(c,j) - xm(c,j))
+                        
+                        ! Calculate surplus heat after melting pore ice
+                        xm2(c,j) = max(0._r8, xm(c,j) - wice0(c,j))
+                        
+                        ! For soil layers with excess ice, use surplus heat to melt excess ice
+                        if (j >= 1 .and. use_polygonal_tundra) then
+                           l = col_pp%landunit(c)
+                           if (lun_pp%ispolygon(l) .and. excess_ice(c,j) > 0._r8 .and. xm2(c,j) > 0._r8) then
+                              excess_ice(c,j) = max(0._r8, wexice0(c,j) - xm2(c,j))
+                           end if
+                           
+                           ! Heat residual including both pore ice and excess ice latent heat
+                           heatr = hm(c,j) - hfus * (wexice0(c,j) - excess_ice(c,j) + &
+                                                      wice0(c,j) - h2osoi_ice(c,j)) / dtime
+                        else
+                           ! Standard calculation (snow or non-polygonal soil)
+                           heatr = hm(c,j) - hfus * (wice0(c,j) - h2osoi_ice(c,j)) / dtime
+                        endif
+                        
+                     else if (xm(c,j) < 0._r8) then  ! Freezing
+                        ! Excess ice does NOT refreeze
                         if (j <= 0) then
                            h2osoi_ice(c,j) = min(wmass0(c,j), wice0(c,j)-xm(c,j))  ! snow
                         else
-                           if (wmass0(c,j) < supercool(c,j)) then
-                              h2osoi_ice(c,j) = 0._r8
+                           if (use_polygonal_tundra) then
+                              l = col_pp%landunit(c)
+                              if (lun_pp%ispolygon(l)) then
+                                 ! Exclude excess ice from freezable water
+                                 if (wmass0(c,j) - wexice0(c,j) < supercool(c,j)) then
+                                    h2osoi_ice(c,j) = 0._r8
+                                 else
+                                    h2osoi_ice(c,j) = min(wmass0(c,j) - wexice0(c,j) - supercool(c,j), &
+                                                           wice0(c,j) - xm(c,j))
+                                 end if
+                              else
+                                 ! Standard freezing for non-polygonal
+                                 if (wmass0(c,j) < supercool(c,j)) then
+                                    h2osoi_ice(c,j) = 0._r8
+                                 else
+                                    h2osoi_ice(c,j) = min(wmass0(c,j) - supercool(c,j), wice0(c,j)-xm(c,j))
+                                 end if
+                              end if
                            else
-                              h2osoi_ice(c,j) = min(wmass0(c,j) - supercool(c,j),wice0(c,j)-xm(c,j))
-                           endif
+                              ! Standard freezing
+                              if (wmass0(c,j) < supercool(c,j)) then
+                                 h2osoi_ice(c,j) = 0._r8
+                              else
+                                 h2osoi_ice(c,j) = min(wmass0(c,j) - supercool(c,j),wice0(c,j)-xm(c,j))
+                              endif
+                           end if
                         endif
                         heatr = hm(c,j) - hfus*(wice0(c,j)-h2osoi_ice(c,j))/dtime
                      endif
 
-                     h2osoi_liq(c,j) = max(0._r8,wmass0(c,j)-h2osoi_ice(c,j))
+                     ! Update liquid water including melted excess ice
+                     h2osoi_liq(c,j) = max(0._r8,wmass0(c,j)-h2osoi_ice(c,j)-excess_ice(c,j))
 
                      if (abs(heatr) > 0._r8) then
                         if (j == snl(c)+1) then
@@ -1621,8 +1704,24 @@ contains
                      endif  ! end of heatr > 0 if-block
 
                      if (j >= 1) then
-                        xmf(c) = xmf(c) + hfus*(wice0(c,j)-h2osoi_ice(c,j))/dtime
+                        ! Calculate melt fluxes including excess ice
+                        if (use_polygonal_tundra) then
+                           l = col_pp%landunit(c)
+                           if (lun_pp%ispolygon(l)) then
+                              ! Excess ice melt flux (kg/m2/s)
+                              qflx_exice_melt(c,j) = max(0._r8, (wexice0(c,j) - excess_ice(c,j)) / dtime)
+                              
+                              ! Total latent heat flux (pore ice + excess ice)
+                              xmf(c) = xmf(c) + hfus*(wice0(c,j) - h2osoi_ice(c,j))/dtime + &
+                                                hfus*(wexice0(c,j) - excess_ice(c,j))/dtime
+                           else
+                              xmf(c) = xmf(c) + hfus*(wice0(c,j)-h2osoi_ice(c,j))/dtime
+                           end if
+                        else
+                           xmf(c) = xmf(c) + hfus*(wice0(c,j)-h2osoi_ice(c,j))/dtime
+                        end if
                      else
+                        ! Snow layers
                         xmf(c) = xmf(c) + hfus*(wice0(c,j)-h2osoi_ice(c,j))/dtime
                      endif
 
@@ -1684,6 +1783,34 @@ contains
             eflx_snomelt_u(c) = eflx_snomelt(c)
          else if (lun_pp%itype(l) == istsoil .or. lun_pp%itype(l) == istcrop) then
             eflx_snomelt_r(c) = eflx_snomelt(c)
+         end if
+      end do
+      
+      ! Calculate excess ice energy flux (following snow melt pattern)
+      ! and update cumulative subsidence since 1989
+      call get_curr_date(year, mon, day, sec)
+      
+      do fc = 1,num_nolakec
+         c = filter_nolakec(fc)
+         
+         ! Column-integrated excess ice latent heat flux (W/m2)
+         eflx_exice_melt(c) = 0._r8
+         
+         if (use_polygonal_tundra) then
+            l = col_pp%landunit(c)
+            if (lun_pp%ispolygon(l)) then
+               ! Sum across all layers for energy flux
+               do j = 1, nlevgrnd
+                  eflx_exice_melt(c) = eflx_exice_melt(c) + qflx_exice_melt(c,j) * hfus
+                  
+                  ! Update cumulative subsidence since 1989
+                  ! (volume change = mass / density)
+                  if (year >= 1989 .and. wexice0(c,j) > excess_ice(c,j)) then
+                     iwp_subsidence(c) = iwp_subsidence(c) + &
+                                         (wexice0(c,j) - excess_ice(c,j)) / denice
+                  end if
+               end do
+            end if
          end if
       end do
 

--- a/components/elm/src/biogeophys/SoilTemperatureMod.F90
+++ b/components/elm/src/biogeophys/SoilTemperatureMod.F90
@@ -1674,9 +1674,18 @@ contains
                         heatr = hm(c,j) - hfus*(wice0(c,j)-h2osoi_ice(c,j))/dtime
                      endif
 
-                     ! Update liquid water including melted excess ice
-                     h2osoi_liq(c,j) = max(0._r8,wmass0(c,j)-h2osoi_ice(c,j)-excess_ice(c,j))
-                     
+                     ! Update liquid water, subtracting excess ice only for polygon tundra soil layers
+                     if (j >= 1 .and. use_polygonal_tundra) then
+                        l = col_pp%landunit(c)
+                        if (lun_pp%ispolygon(l)) then
+                           h2osoi_liq(c,j) = max(0._r8,wmass0(c,j)-h2osoi_ice(c,j)-excess_ice(c,j))
+                        else
+                           h2osoi_liq(c,j) = max(0._r8,wmass0(c,j)-h2osoi_ice(c,j))
+                        end if
+                     else
+                        h2osoi_liq(c,j) = max(0._r8,wmass0(c,j)-h2osoi_ice(c,j))
+                     end if
+
                      if (abs(heatr) > 0._r8) then
                         if (j == snl(c)+1) then
 

--- a/components/elm/src/biogeophys/WaterfluxType.F90
+++ b/components/elm/src/biogeophys/WaterfluxType.F90
@@ -79,9 +79,8 @@ module WaterfluxType
      real(r8), pointer :: qflx_deficit_col         (:)   ! col water deficit to keep non-negative liquid water content (mm H2O)   
      real(r8), pointer :: qflx_floodc_col          (:)   ! col flood water flux at column level
      real(r8), pointer :: qflx_sl_top_soil_col     (:)   ! col liquid water + ice from layer above soil to top soil layer or sent to qflx_qrgwl (mm H2O/s)
-      real(r8), pointer :: qflx_snomelt_col         (:)   ! col snow melt (mm H2O /s)
-      real(r8), pointer :: qflx_exice_melt_col      (:,:) ! col excess ice melt rate (kg/m2/s) per layer
-      real(r8), pointer :: qflx_snow_melt_col       (:)   ! col snow melt (net)
+     real(r8), pointer :: qflx_snomelt_col         (:)   ! col snow melt (mm H2O /s)
+     real(r8), pointer :: qflx_snow_melt_col       (:)   ! col snow melt (net)
      real(r8), pointer :: qflx_qrgwl_col           (:)   ! col qflx_surf at glaciers, wetlands, lakes
      real(r8), pointer :: qflx_runoff_col          (:)   ! col total runoff (qflx_drain+qflx_surf+qflx_qrgwl) (mm H2O /s)
      real(r8), pointer :: qflx_runoff_r_col        (:)   ! col Rural total runoff (qflx_drain+qflx_surf+qflx_qrgwl) (mm H2O /s)
@@ -250,7 +249,6 @@ contains
     allocate(this%qflx_h2osfc_surf_col     (begc:endc))              ; this%qflx_h2osfc_surf_col     (:)   = nan
     allocate(this%qflx_snow_h2osfc_col     (begc:endc))              ; this%qflx_snow_h2osfc_col     (:)   = nan
     allocate(this%qflx_snomelt_col         (begc:endc))              ; this%qflx_snomelt_col         (:)   = nan
-    allocate(this%qflx_exice_melt_col      (begc:endc,1:nlevgrnd)) ; this%qflx_exice_melt_col      (:,:) = nan
     allocate(this%qflx_snow_melt_col       (begc:endc))              ; this%qflx_snow_melt_col       (:)   = nan
     allocate(this%qflx_snofrz_col          (begc:endc))              ; this%qflx_snofrz_col          (:)   = nan
     allocate(this%qflx_snofrz_lyr_col      (begc:endc,-nlevsno+1:0)) ; this%qflx_snofrz_lyr_col      (:,:) = nan

--- a/components/elm/src/biogeophys/WaterfluxType.F90
+++ b/components/elm/src/biogeophys/WaterfluxType.F90
@@ -79,8 +79,9 @@ module WaterfluxType
      real(r8), pointer :: qflx_deficit_col         (:)   ! col water deficit to keep non-negative liquid water content (mm H2O)   
      real(r8), pointer :: qflx_floodc_col          (:)   ! col flood water flux at column level
      real(r8), pointer :: qflx_sl_top_soil_col     (:)   ! col liquid water + ice from layer above soil to top soil layer or sent to qflx_qrgwl (mm H2O/s)
-     real(r8), pointer :: qflx_snomelt_col         (:)   ! col snow melt (mm H2O /s)
-     real(r8), pointer :: qflx_snow_melt_col       (:)   ! col snow melt (net)
+      real(r8), pointer :: qflx_snomelt_col         (:)   ! col snow melt (mm H2O /s)
+      real(r8), pointer :: qflx_exice_melt_col      (:,:) ! col excess ice melt rate (kg/m2/s) per layer
+      real(r8), pointer :: qflx_snow_melt_col       (:)   ! col snow melt (net)
      real(r8), pointer :: qflx_qrgwl_col           (:)   ! col qflx_surf at glaciers, wetlands, lakes
      real(r8), pointer :: qflx_runoff_col          (:)   ! col total runoff (qflx_drain+qflx_surf+qflx_qrgwl) (mm H2O /s)
      real(r8), pointer :: qflx_runoff_r_col        (:)   ! col Rural total runoff (qflx_drain+qflx_surf+qflx_qrgwl) (mm H2O /s)
@@ -249,6 +250,7 @@ contains
     allocate(this%qflx_h2osfc_surf_col     (begc:endc))              ; this%qflx_h2osfc_surf_col     (:)   = nan
     allocate(this%qflx_snow_h2osfc_col     (begc:endc))              ; this%qflx_snow_h2osfc_col     (:)   = nan
     allocate(this%qflx_snomelt_col         (begc:endc))              ; this%qflx_snomelt_col         (:)   = nan
+    allocate(this%qflx_exice_melt_col      (begc:endc,1:nlevgrnd)) ; this%qflx_exice_melt_col      (:,:) = nan
     allocate(this%qflx_snow_melt_col       (begc:endc))              ; this%qflx_snow_melt_col       (:)   = nan
     allocate(this%qflx_snofrz_col          (begc:endc))              ; this%qflx_snofrz_col          (:)   = nan
     allocate(this%qflx_snofrz_lyr_col      (begc:endc,-nlevsno+1:0)) ; this%qflx_snofrz_lyr_col      (:,:) = nan

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -35,7 +35,8 @@ module ColumnDataType
   use soilorder_varcon, only : smax, ks_sorption
   use elm_time_manager, only : is_restart, get_nstep
   use elm_time_manager, only : is_first_step, get_step_size, is_first_restart_step
-  use landunit_varcon , only : istice, istwet, istsoil, istdlak, istcrop, istice_mec, istlowcenpoly, isthighcenpoly
+  use landunit_varcon , only : istice, istwet, istsoil, istdlak, istcrop, istice_mec
+  use landunit_varcon , only : ilowcenpoly, iflatcenpoly, ihighcenpoly
   use column_varcon   , only : icol_road_perv, icol_road_imperv, icol_roof, icol_sunwall, icol_shadewall
   use histFileMod     , only : hist_addfld1d, hist_addfld2d, no_snow_normal
   use histFileMod     , only : hist_addfld_decomp
@@ -1865,10 +1866,24 @@ contains
 
        this%h2osoi_liq_old(c,:) = this%h2osoi_liq(c,:)
        this%h2osoi_ice_old(c,:) = this%h2osoi_ice(c,:)
-       if (use_polygonal_tundra) then
+       if (use_polygonal_tundra .and. lun_pp%ispolygon(l)) then
          this%excess_ice(c,:) = 0.36_r8
          this%iwp_subsidence(c) = 0._r8
          this%frac_melted(c,:)  = 0._r8
+         ! set initial microtopographic parameters
+         if (lun_pp%polygontype(l) .eq. ilowcenpoly) then
+            this%iwp_microrel(c) = 0.4_r8
+            this%iwp_exclvol(c) = 0.2_r8
+            this%iwp_ddep(c) = 0.15_r8
+         else if (lun_pp%polygontype(l) .eq. iflatcenpoly) then
+            this%iwp_microrel(c) = 0.1_r8
+            this%iwp_exclvol(c) = 0.05_r8
+            this%iwp_ddep(c) = 0.01_r8
+         else if (lun_pp%polygontype(l) .eq. ihighcenpoly) then
+            this%iwp_microrel(c) = 0.4_r8
+            this%iwp_exclvol(c) = 0.2_r8
+            this%iwp_ddep(c) = 0.05_r8
+         endif
        end if
     end do
 

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -151,7 +151,7 @@ module ColumnDataType
     real(r8), pointer :: frac_sno_eff       (:)   => null() ! fraction of ground covered by snow (0 to 1)
     real(r8), pointer :: frac_iceold        (:,:) => null() ! fraction of ice relative to the tot water (-nlevsno+1:nlevgrnd)
     real(r8), pointer :: frac_h2osfc        (:)   => null() ! fractional area with surface water greater than zero
-    real(r8), pointer :: frac_h2osfc_act    (:)   => null() ! actural fractional area with surface water greater than zero
+    real(r8), pointer :: frac_h2osfc_act    (:)   => null() ! actual fractional area with surface water greater than zero
     real(r8), pointer :: wf                 (:)   => null() ! soil water as frac. of whc for top 0.05 m (0-1)
     real(r8), pointer :: wf2                (:)   => null() ! soil water as frac. of whc for top 0.17 m (0-1)
     real(r8), pointer :: finundated         (:)   => null() ! fraction of column inundated, for bgc caclulation (0-1)
@@ -1651,6 +1651,9 @@ contains
          ptr_col=this%frac_h2osfc)
     
     this%frac_h2osfc_act(begc:endc) = spval
+    call hist_addfld1d (fname='FH2OSFC_ACT', units='1', &
+         avgflag='A', long_name='fraction of ground covered by surface water, ignoring snow cover', &
+         ptr_col=this%frac_h2osfc_act)
          
     if (use_cn) then
        this%wf(begc:endc) = spval
@@ -2056,6 +2059,14 @@ contains
          interpinic_flag='interp', readvar=readvar, data=this%frac_h2osfc)
     if (flag == 'read' .and. .not. readvar) then
        this%frac_h2osfc(bounds%begc:bounds%endc) = 0.0_r8
+    end if
+
+    call restartvar(ncid=ncid, flag=flag, varname='FH2OSFC_ACT', xtype=ncd_double,  &
+         dim1name='column',&
+         long_name='fraction of ground covered by h2osfc (0 to 1), ignoring snow cover', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%frac_h2osfc_act)
+    if (flag == 'read' .and. .not. readvar) then
+       this%frac_h2osfc_act(bounds%begc:bounds%endc) = 0.0_r8
     end if
 
     if (use_cn) then

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -1871,9 +1871,9 @@ contains
          ! Initialize volumetric fraction to 36%
          this%excess_ice_volfrac(c,:) = 0.36_r8
          
-         ! Convert to mass (kg/m2)
+         ! Convert to mass (kg/m2), using reference (mineral soil) layer thickness
          do j = 1, nlevgrnd
-            this%excess_ice(c,j) = this%excess_ice_volfrac(c,j) * col_pp%dz(c,j) * denice
+            this%excess_ice(c,j) = this%excess_ice_volfrac(c,j) * col_pp%dz_ref(c,j) * denice
          end do
          
          this%iwp_subsidence(c) = 0._r8
@@ -1975,23 +1975,26 @@ contains
               end if
           end if
           
-          ! Convert from volumetric to mass
+          ! Convert from volumetric to mass using reference layer thickness.
+          ! volfrac is always relative to the undeformed (mineral soil) thickness.
           do c = bounds%begc, bounds%endc
               l = col_pp%landunit(c)
               if (lun_pp%ispolygon(l)) then
                   do j = 1, nlevgrnd
-                      this%excess_ice(c,j) = this%excess_ice_volfrac(c,j) * col_pp%dz(c,j) * denice
+                      this%excess_ice(c,j) = this%excess_ice_volfrac(c,j) * col_pp%dz_ref(c,j) * denice
                   end do
               end if
           end do
       else if (flag == 'write') then
-          ! Convert from mass to volumetric before writing
+          ! Convert from mass to volumetric before writing, using reference layer
+          ! thickness so the stored fraction is always relative to the undeformed
+          ! (mineral soil) layer and is independent of deformation state.
           do c = bounds%begc, bounds%endc
               l = col_pp%landunit(c)
               if (lun_pp%ispolygon(l)) then
                   do j = 1, nlevgrnd
-                      if (col_pp%dz(c,j) > 0._r8) then
-                          this%excess_ice_volfrac(c,j) = this%excess_ice(c,j) / (col_pp%dz(c,j) * denice)
+                      if (col_pp%dz_ref(c,j) > 0._r8) then
+                          this%excess_ice_volfrac(c,j) = this%excess_ice(c,j) / (col_pp%dz_ref(c,j) * denice)
                       else
                           this%excess_ice_volfrac(c,j) = 0._r8
                       end if

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -175,8 +175,8 @@ module ColumnDataType
     real(r8), pointer :: iwp_exclvol      (:) => null() ! ice wedge polygon excluded volume (m)
     real(r8), pointer :: iwp_ddep         (:) => null() ! ice wedge polygon depression depth (m)
     real(r8), pointer :: iwp_subsidence   (:) => null() ! ice wedge polygon ground subsidence (m)
-    real(r8), pointer :: excess_ice     (:,:) => null() ! excess ground ice in column (1:nlevgrnd) (0 to 1)
-    real(r8), pointer :: frac_melted    (:,:) => null() ! fraction of layer that has ever thawed (for tracking excess ice removal) (0 to 1)
+    real(r8), pointer :: excess_ice          (:,:) => null() ! excess ground ice mass (kg/m2) (1:nlevgrnd)
+    real(r8), pointer :: excess_ice_volfrac  (:,:) => null() ! excess ice volumetric fraction (0 to 1) (1:nlevgrnd)
     real(r8), pointer :: h2osfc_p         (:) => null() !!! DEBUG
 
   contains
@@ -1471,8 +1471,8 @@ contains
       allocate(this%iwp_exclvol        (begc:endc))                   ; this%iwp_exclvol      (:) = spval
       allocate(this%iwp_ddep           (begc:endc))                   ; this%iwp_ddep         (:) = spval
       allocate(this%iwp_subsidence     (begc:endc))                   ; this%iwp_subsidence   (:) = spval
-      allocate(this%frac_melted        (begc:endc,1:nlevgrnd))        ; this%frac_melted    (:,:) = spval
       allocate(this%excess_ice         (begc:endc,1:nlevgrnd))        ; this%excess_ice     (:,:) = spval
+      allocate(this%excess_ice_volfrac (begc:endc,1:nlevgrnd))        ; this%excess_ice_volfrac(:,:) = spval
     end if
 
     !-----------------------------------------------------------------------
@@ -1514,14 +1514,17 @@ contains
       this%iwp_ddep(begc:endc)          = spval
       this%iwp_exclvol(begc:endc)       = spval
       this%iwp_microrel(begc:endc)      = spval
-      this%frac_melted(begc:endc,:)     = spval
       this%excess_ice(begc:endc,:)      = spval
+      this%excess_ice_volfrac(begc:endc,:) = spval
 
-      call hist_addfld2d (fname='EXCESS_ICE', units = '1', type2d='levgrnd', &
-           avgflag='A', long_name='Excess ground ice (0 to 1)', &
+      ! History output for excess ice mass per layer (for debugging)
+      call hist_addfld2d (fname='EXCESS_ICE', units='kg/m2', type2d='levgrnd', &
+           avgflag='A', long_name='excess ground ice mass per layer', &
            ptr_col=this%excess_ice, l2g_scale_type='veg')
+      
+      ! Cumulative subsidence since 1989
       call hist_addfld1d (fname="SUBSIDENCE", units='m', avgflag='A', &
-            long_name='ground subsidence (m)', ptr_col=this%iwp_subsidence)
+            long_name='cumulative ground subsidence since 1989', ptr_col=this%iwp_subsidence)
       call hist_addfld1d (fname="DEPRESS_DEPTH", units='m', avgflag='A', &
             long_name='microtopographic depression depth (m)', ptr_col=this%iwp_ddep)
       call hist_addfld1d (fname="EXCLUDED_VOL", units='m', avgflag='A', &
@@ -1529,9 +1532,6 @@ contains
             ptr_col=this%iwp_exclvol)
       call hist_addfld1d (fname="MICROREL", units='m', avgflag='A', &
             long_name='microtopographic relief (m)', ptr_col=this%iwp_microrel)
-      call hist_addfld2d (fname="FRAC_MELTED", units='-', type2d='levgrnd', &
-            avgflag='A', long_name='fraction of layer that has melted (-)', &
-            ptr_col=this%frac_melted, l2g_scale_type='veg')
     endif
     !/polygonal tundra
 
@@ -1870,9 +1870,16 @@ contains
        this%h2osoi_liq_old(c,:) = this%h2osoi_liq(c,:)
        this%h2osoi_ice_old(c,:) = this%h2osoi_ice(c,:)
        if (use_polygonal_tundra .and. lun_pp%ispolygon(l)) then
-         this%excess_ice(c,:) = 0.36_r8
+         ! Initialize volumetric fraction to 36%
+         this%excess_ice_volfrac(c,:) = 0.36_r8
+         
+         ! Convert to mass (kg/m2)
+         do j = 1, nlevgrnd
+            this%excess_ice(c,j) = this%excess_ice_volfrac(c,j) * col_pp%dz(c,j) * denice
+         end do
+         
          this%iwp_subsidence(c) = 0._r8
-         this%frac_melted(c,:)  = 0._r8
+         
          ! set initial microtopographic parameters
          if (lun_pp%polygontype(l) .eq. ilowcenpoly) then
             this%iwp_microrel(c) = 0.4_r8
@@ -1951,13 +1958,54 @@ contains
          interpinic_flag='interp', readvar=readvar, data=this%h2osoi_ice)
 
     if (use_polygonal_tundra) then
-      call restartvar(ncid=ncid, flag=flag, varname='EXCESS_ICE', xtype=ncd_double, &
+      ! Write/read volumetric fraction with new name
+      call restartvar(ncid=ncid, flag=flag, varname='EXCESS_ICE_FRAC', xtype=ncd_double, &
            dim1name='column', dim2name='levgrnd', switchdim=.true., &
-           long_name='excess ground ice (0 to 1)', units='1', &
-           interpinic_flag='interp', readvar=readvar, data=this%excess_ice)
+           long_name='excess ground ice volumetric fraction (0 to 1)', units='1', &
+           interpinic_flag='interp', readvar=readvar, data=this%excess_ice_volfrac)
+      
+      ! Convert between volumetric and mass
+      if (flag == 'read') then
+          ! Backward compatibility: try old name if new name fails
+          if (.not. readvar) then
+              call restartvar(ncid=ncid, flag=flag, varname='EXCESS_ICE', xtype=ncd_double, &
+                   dim1name='column', dim2name='levgrnd', switchdim=.true., &
+                   long_name='excess ground ice (old format)', units='1', &
+                   interpinic_flag='interp', readvar=readvar, data=this%excess_ice_volfrac)
+              if (readvar) then
+                  write(iulog,*) 'Read EXCESS_ICE from old format, converted to EXCESS_ICE_FRAC'
+              end if
+          end if
+          
+          ! Convert from volumetric to mass
+          do c = bounds%begc, bounds%endc
+              l = col_pp%landunit(c)
+              if (lun_pp%ispolygon(l)) then
+                  do j = 1, nlevgrnd
+                      this%excess_ice(c,j) = this%excess_ice_volfrac(c,j) * col_pp%dz(c,j) * denice
+                  end do
+              end if
+          end do
+      else if (flag == 'write') then
+          ! Convert from mass to volumetric before writing
+          do c = bounds%begc, bounds%endc
+              l = col_pp%landunit(c)
+              if (lun_pp%ispolygon(l)) then
+                  do j = 1, nlevgrnd
+                      if (col_pp%dz(c,j) > 0._r8) then
+                          this%excess_ice_volfrac(c,j) = this%excess_ice(c,j) / (col_pp%dz(c,j) * denice)
+                      else
+                          this%excess_ice_volfrac(c,j) = 0._r8
+                      end if
+                  end do
+              end if
+          end do
+      end if
+      
+      ! SUBSIDENCE - cumulative tracking since 1989
       call restartvar(ncid=ncid, flag=flag, varname='SUBSIDENCE', xtype=ncd_double, &
            dim1name='column', &
-           long_name='ground subsidence', units='m', &
+           long_name='cumulative ground subsidence since 1989', units='m', &
            interpinic_flag='interp', readvar=readvar, data=this%iwp_subsidence)
       call restartvar(ncid=ncid, flag=flag, varname='DEPRESS_DEPTH', xtype=ncd_double, &
            dim1name='column', &
@@ -1971,10 +2019,6 @@ contains
            dim1name='column', &
            long_name='microtopographic relief', units='m', &
            interpinic_flag='interp', readvar=readvar, data=this%iwp_microrel)
-      call restartvar(ncid=ncid, flag=flag, varname='FRAC_MELTED', xtype=ncd_double, &
-           dim1name='column', dim2name='levgrnd', switchdim=.true., &
-           long_name='fraction of layer that has ever melted', units='-', &
-           interpinic_flag='interp', readvar=readvar, data=this%frac_melted)
     end if
 
     call restartvar(ncid=ncid, flag=flag, varname='SOILP', xtype=ncd_double,  &

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -28,7 +28,7 @@ module ColumnDataType
   use elm_varctl      , only : hist_wrtch4diag, use_century_decomp
   use elm_varctl      , only : get_carbontag, override_bgc_restart_mismatch_dump
   use elm_varctl      , only : pf_hmode, nu_com
-  use elm_varctl      , only : use_extrasnowlayers, use_polygonal_tundra
+  use elm_varctl      , only : use_extrasnowlayers, use_polygonal_tundra, unified_polygonal_tundra
   use elm_varctl      , only : use_fan
   use ch4varcon       , only : allowlakeprod
   use pftvarcon       , only : VMAX_MINSURF_P_vr, KM_MINSURF_P_vr, pinit_beta1, pinit_beta2
@@ -36,7 +36,7 @@ module ColumnDataType
   use elm_time_manager, only : is_restart, get_nstep
   use elm_time_manager, only : is_first_step, get_step_size, is_first_restart_step
   use landunit_varcon , only : istice, istwet, istsoil, istdlak, istcrop, istice_mec
-  use landunit_varcon , only : ilowcenpoly, iflatcenpoly, ihighcenpoly
+  use landunit_varcon , only : ilowcenpoly, iflatcenpoly, ihighcenpoly, iunifiedpoly
   use column_varcon   , only : icol_road_perv, icol_road_imperv, icol_roof, icol_sunwall, icol_shadewall
   use histFileMod     , only : hist_addfld1d, hist_addfld2d, no_snow_normal
   use histFileMod     , only : hist_addfld_decomp
@@ -178,6 +178,7 @@ module ColumnDataType
     real(r8), pointer :: excess_ice          (:,:) => null() ! excess ground ice mass (kg/m2) (1:nlevgrnd)
     real(r8), pointer :: excess_ice_volfrac  (:,:) => null() ! excess ice volumetric fraction (0 to 1) (1:nlevgrnd)
     real(r8), pointer :: h2osfc_p         (:) => null() !!! DEBUG
+    real(r8), pointer :: degradation_index (:) => null() !!! DEBUG
 
   contains
     procedure, public :: Init    => col_ws_init
@@ -1476,8 +1477,8 @@ contains
       allocate(this%iwp_subsidence     (begc:endc))                   ; this%iwp_subsidence   (:) = spval
       allocate(this%excess_ice         (begc:endc,1:nlevgrnd))        ; this%excess_ice     (:,:) = spval
       allocate(this%excess_ice_volfrac (begc:endc,1:nlevgrnd))        ; this%excess_ice_volfrac(:,:) = spval
-      if (universal_polygonal_tundra) then
-         allocate(this%degradation_index  (begc:endc))                   ; this%degredation_index(:) = spval
+      if (unified_polygonal_tundra) then
+         allocate(this%degradation_index  (begc:endc))                ; this%degradation_index(:) = spval
       end if   
     end if
 
@@ -1522,7 +1523,7 @@ contains
       this%iwp_microrel(begc:endc)      = spval
       this%excess_ice(begc:endc,:)      = 0._r8 ! specify as zero to avoid any excess ice in non-polygonal tundra cells
       this%excess_ice_volfrac(begc:endc,:) = 0._r8
-      if (universal_polygonal_tundra) then
+      if (unified_polygonal_tundra) then
          this%degradation_index(begc:endc) = spval
       end if   
 
@@ -1541,7 +1542,7 @@ contains
             ptr_col=this%iwp_exclvol)
       call hist_addfld1d (fname="MICROREL", units='m', avgflag='A', &
             long_name='microtopographic relief (m)', ptr_col=this%iwp_microrel)
-      if (universal_polygonal_tundra) then
+      if (unified_polygonal_tundra) then
          call hist_addfld1d (fname="DEGRAD_INDEX", units='1', avgflag='A', &
                long_name='polygonal tundra degradation index (0-1)', ptr_col=this%degradation_index)
       endif
@@ -1901,7 +1902,7 @@ contains
             this%iwp_microrel(c) = 0.4_r8
             this%iwp_exclvol(c) = 0.2_r8
             this%iwp_ddep(c) = 0.05_r8
-         else if (lun_pp%polygontype(l) .eq. iuniversalpoly) then
+         else if (lun_pp%polygontype(l) .eq. iunifiedpoly) then
             ! set as low-cen polygon for now
             this%iwp_microrel(c) = 0.4_r8
             this%iwp_exclvol(c) = 0.2_r8
@@ -1920,7 +1921,7 @@ contains
     ! Read/Write column water state information to/from restart file.
     !
     ! !USES:
-    use elm_varctl, only : use_lake_wat_storage, do_budgets
+    use elm_varctl, only : use_lake_wat_storage, do_budgets, unified_polygonal_tundra
     !
     ! !ARGUMENTS:
     class(column_water_state) :: this
@@ -2036,12 +2037,13 @@ contains
            dim1name='column', &
            long_name='microtopographic relief', units='m', &
            interpinic_flag='interp', readvar=readvar, data=this%iwp_microrel)
-      if (universal_polygonal_tundra) then
+      if (unified_polygonal_tundra) then
          call restartvar(ncid=ncid, flag=flag, varname='DEGRAD_INDEX', xtype=ncd_double, &
               dim1name='column', &
               long_name='polygonal tundra degradation index (0-1)', units='1', &
               interpinic_flag='interp', readvar=readvar, data=this%degradation_index)
       end if
+   end if
 
     call restartvar(ncid=ncid, flag=flag, varname='SOILP', xtype=ncd_double,  &
          dim1name='column', dim2name='levgrnd', switchdim=.true., &

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -1476,6 +1476,9 @@ contains
       allocate(this%iwp_subsidence     (begc:endc))                   ; this%iwp_subsidence   (:) = spval
       allocate(this%excess_ice         (begc:endc,1:nlevgrnd))        ; this%excess_ice     (:,:) = spval
       allocate(this%excess_ice_volfrac (begc:endc,1:nlevgrnd))        ; this%excess_ice_volfrac(:,:) = spval
+      if (universal_polygonal_tundra) then
+         allocate(this%degradation_index  (begc:endc))                   ; this%degredation_index(:) = spval
+      end if   
     end if
 
     !-----------------------------------------------------------------------
@@ -1519,6 +1522,9 @@ contains
       this%iwp_microrel(begc:endc)      = spval
       this%excess_ice(begc:endc,:)      = 0._r8 ! specify as zero to avoid any excess ice in non-polygonal tundra cells
       this%excess_ice_volfrac(begc:endc,:) = 0._r8
+      if (universal_polygonal_tundra) then
+         this%degradation_index(begc:endc) = spval
+      end if   
 
       ! History output for excess ice mass per layer (for debugging)
       call hist_addfld2d (fname='EXCESS_ICE', units='kg/m2', type2d='levgrnd', &
@@ -1535,6 +1541,10 @@ contains
             ptr_col=this%iwp_exclvol)
       call hist_addfld1d (fname="MICROREL", units='m', avgflag='A', &
             long_name='microtopographic relief (m)', ptr_col=this%iwp_microrel)
+      if (universal_polygonal_tundra) then
+         call hist_addfld1d (fname="DEGRAD_INDEX", units='1', avgflag='A', &
+               long_name='polygonal tundra degradation index (0-1)', ptr_col=this%degradation_index)
+      endif
     endif
     !/polygonal tundra
 
@@ -1891,7 +1901,13 @@ contains
             this%iwp_microrel(c) = 0.4_r8
             this%iwp_exclvol(c) = 0.2_r8
             this%iwp_ddep(c) = 0.05_r8
+         else if (lun_pp%polygontype(l) .eq. iuniversalpoly) then
+            ! set as low-cen polygon for now
+            this%iwp_microrel(c) = 0.4_r8
+            this%iwp_exclvol(c) = 0.2_r8
+            this%iwp_ddep(c) = 0.15_r8
          endif
+
        end if
     end do
 
@@ -2020,7 +2036,12 @@ contains
            dim1name='column', &
            long_name='microtopographic relief', units='m', &
            interpinic_flag='interp', readvar=readvar, data=this%iwp_microrel)
-    end if
+      if (universal_polygonal_tundra) then
+         call restartvar(ncid=ncid, flag=flag, varname='DEGRAD_INDEX', xtype=ncd_double, &
+              dim1name='column', &
+              long_name='polygonal tundra degradation index (0-1)', units='1', &
+              interpinic_flag='interp', readvar=readvar, data=this%degradation_index)
+      end if
 
     call restartvar(ncid=ncid, flag=flag, varname='SOILP', xtype=ncd_double,  &
          dim1name='column', dim2name='levgrnd', switchdim=.true., &

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -423,6 +423,7 @@ module ColumnDataType
     real(r8), pointer :: eflx_snomelt            (:)   => null() ! snow melt heat flux (W/m**2)
     real(r8), pointer :: eflx_snomelt_r          (:)   => null() ! rural snow melt heat flux (W/m2)
     real(r8), pointer :: eflx_snomelt_u          (:)   => null() ! urban snow melt heat flux (W/m2)
+    real(r8), pointer :: eflx_exice_melt         (:)   => null() ! excess ice melt latent heat flux (W/m2)
     real(r8), pointer :: eflx_bot                (:)   => null() ! heat flux from beneath the soil or ice column (W/m2)
     real(r8), pointer :: eflx_fgr12              (:)   => null() ! ground heat flux between soil layers 1 and 2 (W/m2)
     real(r8), pointer :: eflx_fgr                (:,:) => null() ! (rural) soil downward heat flux (W/m2) (1:nlevgrnd)  (pos upward; usually eflx_bot >= 0)
@@ -504,6 +505,7 @@ module ColumnDataType
     real(r8), pointer :: qflx_snomelt         (:)   => null() ! snow melt (mm H2O /s)
     real(r8), pointer :: qflx_snow_melt       (:)   => null() ! snow melt (net)
     real(r8), pointer :: qflx_snomelt_lyr     (:,:) => null() ! snow melt (net)
+    real(r8), pointer :: qflx_exice_melt      (:,:) => null() ! excess ice melt (kg/m2/s) per layer
     real(r8), pointer :: qflx_qrgwl           (:)   => null() ! qflx_surf at glaciers, wetlands, lakes
     real(r8), pointer :: qflx_runoff          (:)   => null() ! total runoff (qflx_drain+qflx_surf+qflx_qrgwl) (mm H2O /s)
     real(r8), pointer :: qflx_runoff_r        (:)   => null() ! Rural total runoff (qflx_drain+qflx_surf+qflx_qrgwl) (mm H2O /s)
@@ -1762,9 +1764,6 @@ contains
                    else
                       this%h2osoi_vol(c,j) = 0.15_r8
                    endif
-                   if (use_polygonal_tundra) then
-                     this%frac_melted(c,j) = 0._r8
-                   end if
                 endif
              end do
           else if (lun_pp%urbpoi(l)) then
@@ -5713,6 +5712,7 @@ contains
     allocate(this%eflx_snomelt         (begc:endc))              ; this%eflx_snomelt         (:)   = spval
     allocate(this%eflx_snomelt_r       (begc:endc))              ; this%eflx_snomelt_r       (:)   = spval
     allocate(this%eflx_snomelt_u       (begc:endc))              ; this%eflx_snomelt_u       (:)   = spval
+    allocate(this%eflx_exice_melt      (begc:endc))              ; this%eflx_exice_melt      (:)   = spval
     allocate(this%eflx_bot             (begc:endc))              ; this%eflx_bot             (:)   = spval
     allocate(this%eflx_fgr12           (begc:endc))              ; this%eflx_fgr12           (:)   = spval
     allocate(this%eflx_fgr             (begc:endc, 1:nlevgrnd))  ; this%eflx_fgr             (:,:) = spval
@@ -5755,7 +5755,10 @@ contains
      call hist_addfld1d (fname='FSM_U',  units='W/m^2',  &
           avgflag='A', long_name='Urban snow melt heat flux', &
            ptr_col=this%eflx_snomelt_u, c2l_scale_type='urbanf', set_nourb=spval)
-
+    this%eflx_exice_melt(begc:endc) = spval
+     call hist_addfld1d (fname='EXICE_MELT_COL',  units='W/m^2',  &
+          avgflag='A', long_name='Excess ice melt latent heat flux', &
+           ptr_col=this%eflx_exice_melt, c2l_scale_type='urbanf', set_nourb=spval)
     this%eflx_building_heat(begc:endc) = spval
      call hist_addfld1d (fname='BUILDHEAT', units='W/m^2',  &
           avgflag='A', long_name='heat flux from urban building interior to walls and roof', &
@@ -5899,6 +5902,7 @@ contains
     allocate(this%qflx_snomelt           (begc:endc))             ; this%qflx_snomelt         (:)   = spval
     allocate(this%qflx_snomelt_lyr       (begc:endc,-nlevsno+1:0)) ; this%qflx_snomelt_lyr    (:,:) = spval
     allocate(this%qflx_snow_melt         (begc:endc))             ; this%qflx_snow_melt       (:)   = spval
+    allocate(this%qflx_exice_melt        (begc:endc,1:nlevgrnd))  ; this%qflx_exice_melt      (:,:) = spval
     allocate(this%qflx_qrgwl             (begc:endc))             ; this%qflx_qrgwl           (:)   = spval
     allocate(this%qflx_runoff            (begc:endc))             ; this%qflx_runoff          (:)   = spval
     allocate(this%qflx_runoff_r          (begc:endc))             ; this%qflx_runoff_r        (:)   = spval

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -1528,7 +1528,7 @@ contains
       end if   
 
       ! History output for excess ice mass per layer (for debugging)
-      call hist_addfld2d (fname='EXCESS_ICE', units='kg/m2', type2d='levgrnd', &
+      call hist_addfld2d (fname='EXCESS_ICE', units='kg/m2', type2d='levsoi', &
            avgflag='A', long_name='excess ground ice mass per layer', &
            ptr_col=this%excess_ice, l2g_scale_type='veg')
       
@@ -1880,10 +1880,10 @@ contains
        this%h2osoi_ice_old(c,:) = this%h2osoi_ice(c,:)
        if (use_polygonal_tundra .and. lun_pp%ispolygon(l)) then
          ! Initialize volumetric fraction to 36%
-         this%excess_ice_volfrac(c,:) = 0.36_r8
+         this%excess_ice_volfrac(c,1:nlevsoi) = 0.36_r8
          
          ! Convert to mass (kg/m2), using reference (mineral soil) layer thickness
-         do j = 1, nlevgrnd
+         do j = 1, nlevsoi
             this%excess_ice(c,j) = this%excess_ice_volfrac(c,j) * col_pp%dz_ref(c,j) * denice
          end do
          

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -505,7 +505,8 @@ module ColumnDataType
     real(r8), pointer :: qflx_snomelt         (:)   => null() ! snow melt (mm H2O /s)
     real(r8), pointer :: qflx_snow_melt       (:)   => null() ! snow melt (net)
     real(r8), pointer :: qflx_snomelt_lyr     (:,:) => null() ! snow melt (net)
-    real(r8), pointer :: qflx_exice_melt      (:,:) => null() ! excess ice melt (kg/m2/s) per layer
+    real(r8), pointer :: qflx_exice_melt      (:)   => null() ! excess ice melt (mm H2O/s)
+    real(r8), pointer :: qflx_exice_melt_lyr  (:,:) => null() ! excess ice melt (kg/m2/s) per layer
     real(r8), pointer :: qflx_qrgwl           (:)   => null() ! qflx_surf at glaciers, wetlands, lakes
     real(r8), pointer :: qflx_runoff          (:)   => null() ! total runoff (qflx_drain+qflx_surf+qflx_qrgwl) (mm H2O /s)
     real(r8), pointer :: qflx_runoff_r        (:)   => null() ! Rural total runoff (qflx_drain+qflx_surf+qflx_qrgwl) (mm H2O /s)
@@ -1516,8 +1517,8 @@ contains
       this%iwp_ddep(begc:endc)          = spval
       this%iwp_exclvol(begc:endc)       = spval
       this%iwp_microrel(begc:endc)      = spval
-      this%excess_ice(begc:endc,:)      = spval
-      this%excess_ice_volfrac(begc:endc,:) = spval
+      this%excess_ice(begc:endc,:)      = 0._r8 ! specify as zero to avoid any excess ice in non-polygonal tundra cells
+      this%excess_ice_volfrac(begc:endc,:) = 0._r8
 
       ! History output for excess ice mass per layer (for debugging)
       call hist_addfld2d (fname='EXCESS_ICE', units='kg/m2', type2d='levgrnd', &
@@ -1757,10 +1758,8 @@ contains
                 if (j > nlevbed) then
                    this%h2osoi_vol(c,j) = 0.0_r8
                 else
-		             if (use_fates .or. use_hydrstress) then
+		             if (use_fates .or. use_hydrstress .or. use_arctic_init) then
                       this%h2osoi_vol(c,j) = 0.70_r8*watsat_input(c,j) !0.15_r8 to avoid very dry conditions that cause errors in FATES
-                   else if (use_arctic_init) then
-                      this%h2osoi_vol(c,j) = watsat_input(c,j) ! start saturated for arctic
                    else
                       this%h2osoi_vol(c,j) = 0.15_r8
                    endif
@@ -5902,7 +5901,8 @@ contains
     allocate(this%qflx_snomelt           (begc:endc))             ; this%qflx_snomelt         (:)   = spval
     allocate(this%qflx_snomelt_lyr       (begc:endc,-nlevsno+1:0)) ; this%qflx_snomelt_lyr    (:,:) = spval
     allocate(this%qflx_snow_melt         (begc:endc))             ; this%qflx_snow_melt       (:)   = spval
-    allocate(this%qflx_exice_melt        (begc:endc,1:nlevgrnd))  ; this%qflx_exice_melt      (:,:) = spval
+    allocate(this%qflx_exice_melt        (begc:endc))             ; this%qflx_exice_melt      (:)   = spval
+    allocate(this%qflx_exice_melt_lyr    (begc:endc,1:nlevgrnd))  ; this%qflx_exice_melt_lyr  (:,:) = spval
     allocate(this%qflx_qrgwl             (begc:endc))             ; this%qflx_qrgwl           (:)   = spval
     allocate(this%qflx_runoff            (begc:endc))             ; this%qflx_runoff          (:)   = spval
     allocate(this%qflx_runoff_r          (begc:endc))             ; this%qflx_runoff_r        (:)   = spval
@@ -6015,6 +6015,16 @@ contains
           avgflag='A', long_name='snow melt per snow layer', &
            ptr_col=this%qflx_snomelt_lyr,no_snow_behavior=no_snow_normal, c2l_scale_type='urbanf')
 
+    this%qflx_exice_melt(begc:endc) = spval
+     call hist_addfld1d (fname='QEXCESSICE',  units='mm/s',  &
+          avgflag='A', long_name='excess ice melt', &
+           ptr_col=this%qflx_exice_melt, c2l_scale_type='urbanf')
+
+    this%qflx_exice_melt_lyr(begc:endc,1:nlevgrnd) = spval
+     call hist_addfld2d (fname='QEXCESSICE_LYR',  units='mm/s',type2d='levgrnd',&
+          avgflag='A', long_name='excess ice per soil layer', &
+           ptr_col=this%qflx_exice_melt_lyr, c2l_scale_type='urbanf')
+
     this%qflx_qrgwl(begc:endc) = spval
      call hist_addfld1d (fname='QRGWL',  units='mm/s',  &
           avgflag='A', long_name='surface runoff at glaciers (liquid only), wetlands, lakes', &
@@ -6112,7 +6122,8 @@ contains
     this%qflx_dew_snow (begc:endc) = 0.0_r8
 
     this%qflx_h2osfc_surf(begc:endc) = 0._r8
-    this%qflx_snow_melt  (begc:endc)   = 0._r8
+    this%qflx_snow_melt  (begc:endc) = 0._r8
+    this%qflx_exice_melt (begc:endc) = 0._r8
 
     this%dwb(begc:endc) = 0._r8
     this%qflx_surf_irrig(begc:endc) = 0._r8

--- a/components/elm/src/data_types/ColumnType.F90
+++ b/components/elm/src/data_types/ColumnType.F90
@@ -62,6 +62,7 @@ module ColumnType
      ! vertical levels
      integer , pointer :: snl          (:)   => null() ! number of snow layers
      real(r8), pointer :: dz           (:,:) => null() ! layer thickness (m)  (-nlevsno+1:nlevgrnd)
+     real(r8), pointer :: dz_ref       (:,:) => null() ! reference (mineral soil) layer thickness (m) (1:nlevgrnd)
      real(r8), pointer :: z            (:,:) => null() ! layer depth (m) (-nlevsno+1:nlevgrnd)
      real(r8), pointer :: zi           (:,:) => null() ! interface level below a "z" level (m) (-nlevsno+0:nlevgrnd)
      real(r8), pointer :: zii          (:)   => null() ! convective boundary height [m]
@@ -117,6 +118,7 @@ contains
     ! The following is set in initVerticalMod
     allocate(this%snl         (begc:endc))                     ; this%snl         (:)   = ispval  !* cannot be averaged up
     allocate(this%dz          (begc:endc,-nlevsno+1:nlevgrnd)) ; this%dz          (:,:) = spval
+    allocate(this%dz_ref      (begc:endc, 1:nlevgrnd))         ; this%dz_ref      (:,:) = spval
     allocate(this%z           (begc:endc,-nlevsno+1:nlevgrnd)) ; this%z           (:,:) = spval
     allocate(this%zi          (begc:endc,-nlevsno+0:nlevgrnd)) ; this%zi          (:,:) = spval
     allocate(this%zii         (begc:endc))                     ; this%zii         (:)   = spval
@@ -161,6 +163,7 @@ contains
     deallocate(this%active     )
     deallocate(this%snl        )
     deallocate(this%dz         )
+    deallocate(this%dz_ref     )
     deallocate(this%z          )
     deallocate(this%zi         )
     deallocate(this%zii        )

--- a/components/elm/src/data_types/ColumnType.F90
+++ b/components/elm/src/data_types/ColumnType.F90
@@ -63,6 +63,7 @@ module ColumnType
      integer , pointer :: snl          (:)   => null() ! number of snow layers
      real(r8), pointer :: dz           (:,:) => null() ! layer thickness (m)  (-nlevsno+1:nlevgrnd)
      real(r8), pointer :: dz_ref       (:,:) => null() ! reference (mineral soil) layer thickness (m) (1:nlevgrnd)
+     real(r8), pointer :: volrat       (:,:) => null() ! Volume ratio between old and new dz if dz shrinks due to excess ice melt (1:nlevgrnd)
      real(r8), pointer :: z            (:,:) => null() ! layer depth (m) (-nlevsno+1:nlevgrnd)
      real(r8), pointer :: zi           (:,:) => null() ! interface level below a "z" level (m) (-nlevsno+0:nlevgrnd)
      real(r8), pointer :: zii          (:)   => null() ! convective boundary height [m]
@@ -119,6 +120,7 @@ contains
     allocate(this%snl         (begc:endc))                     ; this%snl         (:)   = ispval  !* cannot be averaged up
     allocate(this%dz          (begc:endc,-nlevsno+1:nlevgrnd)) ; this%dz          (:,:) = spval
     allocate(this%dz_ref      (begc:endc, 1:nlevgrnd))         ; this%dz_ref      (:,:) = spval
+    allocate(this%volrat      (begc:endc, 1:nlevgrnd))         ; this%volrat      (:,:) = spval
     allocate(this%z           (begc:endc,-nlevsno+1:nlevgrnd)) ; this%z           (:,:) = spval
     allocate(this%zi          (begc:endc,-nlevsno+0:nlevgrnd)) ; this%zi          (:,:) = spval
     allocate(this%zii         (begc:endc))                     ; this%zii         (:)   = spval
@@ -164,6 +166,7 @@ contains
     deallocate(this%snl        )
     deallocate(this%dz         )
     deallocate(this%dz_ref     )
+    deallocate(this%volrat     )
     deallocate(this%z          )
     deallocate(this%zi         )
     deallocate(this%zii        )

--- a/components/elm/src/main/ExcessIceMod.F90
+++ b/components/elm/src/main/ExcessIceMod.F90
@@ -12,7 +12,7 @@ module ExcessIceMod
   !
   ! !USES:
   use shr_kind_mod   , only : r8 => shr_kind_r8
-  use elm_varpar     , only : nlevgrnd
+  use elm_varpar     , only : nlevsoi
   use elm_varcon     , only : denice
   use elm_varctl     , only : use_polygonal_tundra
   use decompMod      , only : bounds_type
@@ -75,7 +75,7 @@ contains
 
     zi_bot = 0._r8
     col_pp%volrat(c,:) = 1._r8 ! This should always be 1 unless the layer currently is shrinking in this timestep.
-    do j = 1, nlevgrnd
+    do j = 1, nlevsoi
        dz_orig = col_pp%dz(c,j)
        col_pp%dz(c,j) = col_pp%dz_ref(c,j) + col_ws%excess_ice(c,j) / denice
        col_pp%z(c,j)  = zi_bot + 0.5_r8 * col_pp%dz(c,j)

--- a/components/elm/src/main/ExcessIceMod.F90
+++ b/components/elm/src/main/ExcessIceMod.F90
@@ -70,14 +70,21 @@ contains
     ! !LOCAL VARIABLES:
     integer  :: j
     real(r8) :: zi_bot
+    real(r8) :: dz_orig ! input dz prior to any compression, used to calculate volrat.
     !-----------------------------------------------------------------------
 
     zi_bot = 0._r8
+    col_pp%volrat(c,:) = 1._r8 ! This should always be 1 unless the layer currently is shrinking in this timestep.
     do j = 1, nlevgrnd
+       dz_orig = col_pp%dz(c,j)
        col_pp%dz(c,j) = col_pp%dz_ref(c,j) + col_ws%excess_ice(c,j) / denice
        col_pp%z(c,j)  = zi_bot + 0.5_r8 * col_pp%dz(c,j)
        col_pp%zi(c,j) = zi_bot + col_pp%dz(c,j)
        zi_bot = col_pp%zi(c,j)
+       ! calculate volume ratio to scale molar concentrations of BGC species
+       ! (i.e., layer compression decreases volume but doesn't remove chemical speices,
+       ! so it should increase molar concentrations)
+       col_pp%volrat(c,j) = dz_orig/col_pp%dz(c,j)
     end do
     col_pp%zi(c,0) = 0._r8   ! surface interface (always 0)
 

--- a/components/elm/src/main/ExcessIceMod.F90
+++ b/components/elm/src/main/ExcessIceMod.F90
@@ -1,0 +1,86 @@
+module ExcessIceMod
+
+  !-----------------------------------------------------------------------
+  ! !DESCRIPTION:
+  ! Routines for updating soil layer geometry (dz, z, zi) based on excess ice
+  ! content in polygon tundra columns. When excess ice is present, layers are
+  ! physically larger than the reference (mineral-soil-only) thickness; as ice
+  ! melts (thermokarst), layers compress back toward their reference thickness.
+  !
+  ! Core formula:
+  !   dz(c,j) = dz_ref(c,j) + excess_ice(c,j) / denice
+  !
+  ! !USES:
+  use shr_kind_mod   , only : r8 => shr_kind_r8
+  use elm_varpar     , only : nlevgrnd
+  use elm_varcon     , only : denice
+  use elm_varctl     , only : use_polygonal_tundra
+  use decompMod      , only : bounds_type
+  use LandunitType   , only : lun_pp
+  use ColumnType     , only : col_pp
+  use ColumnDataType , only : col_ws
+  !
+  ! !PUBLIC TYPES:
+  implicit none
+  save
+  private
+  !
+  ! !PUBLIC MEMBER FUNCTIONS:
+  public :: inflate_layers_from_excess_ice
+  public :: recompute_layer_geometry
+  !------------------------------------------------------------------------
+
+contains
+
+  !------------------------------------------------------------------------
+  subroutine inflate_layers_from_excess_ice(bounds)
+    !
+    ! !DESCRIPTION:
+    ! Called once after col_ws%Init (or after restart read) to set deformed
+    ! dz, z, zi for polygon tundra columns based on their current excess ice.
+    ! All other column types are left unchanged.
+    !
+    ! !ARGUMENTS:
+    type(bounds_type), intent(in) :: bounds
+    !
+    ! !LOCAL VARIABLES:
+    integer :: c, l
+    !-----------------------------------------------------------------------
+
+    do c = bounds%begc, bounds%endc
+       if (.not. col_pp%active(c)) cycle
+       l = col_pp%landunit(c)
+       if (.not. (use_polygonal_tundra .and. lun_pp%ispolygon(l))) cycle
+       call recompute_layer_geometry(c)
+    end do
+
+  end subroutine inflate_layers_from_excess_ice
+
+  !------------------------------------------------------------------------
+  subroutine recompute_layer_geometry(c)
+    !
+    ! !DESCRIPTION:
+    ! Update dz, z, zi for column c from dz_ref and current excess_ice.
+    ! Snow layers (indices <= 0) are not touched.
+    ! Should only be called for active polygon tundra columns.
+    !
+    ! !ARGUMENTS:
+    integer, intent(in) :: c
+    !
+    ! !LOCAL VARIABLES:
+    integer  :: j
+    real(r8) :: zi_bot
+    !-----------------------------------------------------------------------
+
+    zi_bot = 0._r8
+    do j = 1, nlevgrnd
+       col_pp%dz(c,j) = col_pp%dz_ref(c,j) + col_ws%excess_ice(c,j) / denice
+       col_pp%z(c,j)  = zi_bot + 0.5_r8 * col_pp%dz(c,j)
+       col_pp%zi(c,j) = zi_bot + col_pp%dz(c,j)
+       zi_bot = col_pp%zi(c,j)
+    end do
+    col_pp%zi(c,0) = 0._r8   ! surface interface (always 0)
+
+  end subroutine recompute_layer_geometry
+
+end module ExcessIceMod

--- a/components/elm/src/main/controlMod.F90
+++ b/components/elm/src/main/controlMod.F90
@@ -358,7 +358,7 @@ contains
 
    ! NGEE Arctic options
    namelist /elm_inparm/ &
-         use_polygonal_tundra, use_arctic_init
+         use_polygonal_tundra, unified_polygonal_tundra, use_arctic_init
     ! ----------------------------------------------------------------------
     ! Default values
     ! ----------------------------------------------------------------------

--- a/components/elm/src/main/elm_initializeMod.F90
+++ b/components/elm/src/main/elm_initializeMod.F90
@@ -88,7 +88,7 @@ contains
     use filterMod                 , only: allocFilters
     use reweightMod               , only: reweight_wrapup
     use topounit_varcon           , only: max_topounits, has_topounit, topounit_varcon_init
-    use elm_varctl                , only: use_top_solar_rad, use_polygonal_tundra
+    use elm_varctl                , only: use_top_solar_rad, use_polygonal_tundra, unified_polygonal_tundra
     !
     ! !LOCAL VARIABLES:
     integer           :: ier                     ! error status
@@ -269,7 +269,11 @@ contains
     ! Allocate surface grid dynamic memory (just gridcell bounds dependent)
 
     if (use_polygonal_tundra) then
-      allocate (wt_lunit     (begg:endg,1:max_topounits, max_lunit           ))
+      if (unified_polygonal_tundra) then
+         allocate (wt_lunit     (begg:endg,1:max_topounits, max_lunit           ))
+      else
+         allocate (wt_lunit     (begg:endg,1:max_topounits, max_lunit - 1       ))
+      endif
     else
       allocate (wt_lunit     (begg:endg,1:max_topounits, max_non_poly_lunit  ))
     end if

--- a/components/elm/src/main/elm_initializeMod.F90
+++ b/components/elm/src/main/elm_initializeMod.F90
@@ -265,7 +265,7 @@ contains
     ! that will call surfrd_get_special which in turn calls check_urban
 
     call UrbanInput(begg, endg, mode='initialize')
-
+    
     ! Allocate surface grid dynamic memory (just gridcell bounds dependent)
 
     if (use_polygonal_tundra) then
@@ -277,6 +277,9 @@ contains
     else
       allocate (wt_lunit     (begg:endg,1:max_topounits, max_non_poly_lunit  ))
     end if
+
+    wt_lunit(:,:,:) = 0._r8
+
     allocate (urban_valid  (begg:endg,1:max_topounits                      ))
     !allocate (wt_nat_patch (begg:endg,1:max_topounits, surfpft_lb:surfpft_ub ))
     !allocate (wt_cft       (begg:endg,1:max_topounits, cft_lb:cft_ub       ))
@@ -290,6 +293,7 @@ contains
        allocate (topo_glc_mec(1,1,1))
     endif
     allocate (wt_polygon (begg:endg,1:max_topounits, max_polygon))
+    wt_polygon(:,:,:) = 0._r8
     allocate (wt_tunit  (begg:endg,1:max_topounits  ))
     allocate (elv_tunit (begg:endg,1:max_topounits  ))
     allocate (slp_tunit (begg:endg,1:max_topounits  ))
@@ -307,6 +311,7 @@ contains
     !
     ! a few arrays allocation previously done above is moved here i.e. after this 'pftconrd' call
     allocate (wt_nat_patch (begg:endg,1:max_topounits, surfpft_lb:surfpft_ub ))
+    wt_nat_patch(:,:,:) = 0._r8
     allocate (wt_cft       (begg:endg,1:max_topounits, cft_lb:cft_ub       ))
     allocate (fert_cft     (begg:endg,1:max_topounits, cft_lb:cft_ub       ))
     allocate (fert_p_cft   (begg:endg,1:max_topounits, cft_lb:cft_ub       ))

--- a/components/elm/src/main/elm_instMod.F90
+++ b/components/elm/src/main/elm_instMod.F90
@@ -267,7 +267,7 @@ contains
     use elm_varcon                        , only : h2osno_max, bdsno, bdfirn
     use domainMod                         , only : ldomain
     use elm_varpar                        , only : nlevsno, numpft
-    use elm_varctl                        , only : single_column, fsurdat, scmlat, scmlon, use_extrasnowlayers
+    use elm_varctl                        , only : single_column, fsurdat, scmlat, scmlon, use_extrasnowlayers, use_polygonal_tundra
     use controlMod                        , only : nlfilename
     use SoilWaterRetentionCurveFactoryMod , only : create_soil_water_retention_curve
     use fileutils                         , only : getfil
@@ -275,6 +275,7 @@ contains
     use SoilorderConType                  , only : soilorderconInit
     use LakeCon                           , only : LakeConInit
     use initVerticalMod                   , only : initVertical
+    use ExcessIceMod                      , only : inflate_layers_from_excess_ice
     ! !ARGUMENTS
     implicit none
     type(bounds_type), intent(in) :: bounds_proc
@@ -425,6 +426,12 @@ contains
          h2osno_col(begc:endc),                    &
          snow_depth_col(begc:endc),                &
          soilstate_vars%watsat_col(begc:endc, 1:))
+
+    ! Inflate soil layer geometry for polygon tundra columns based on initial excess ice
+    if (use_polygonal_tundra) then
+       call inflate_layers_from_excess_ice(bounds_proc)
+    end if
+
     call veg_ws%Init(bounds_proc%begp_all, bounds_proc%endp_all)
 
     call waterflux_vars%init(bounds_proc)

--- a/components/elm/src/main/elm_varctl.F90
+++ b/components/elm/src/main/elm_varctl.F90
@@ -410,7 +410,8 @@ module elm_varctl
   ! NGEE Arctic parameterizations
   !----------------------------------------------------------
   logical, public :: use_polygonal_tundra = .false.
-  logical, public :: use_arctic_init     = .false.
+  logical, public :: prohibit_subsidence  = .false.
+  logical, public :: use_arctic_init      = .false.
 
   !----------------------------------------------------------
   ! VSFM switches

--- a/components/elm/src/main/elm_varctl.F90
+++ b/components/elm/src/main/elm_varctl.F90
@@ -410,6 +410,7 @@ module elm_varctl
   ! NGEE Arctic parameterizations
   !----------------------------------------------------------
   logical, public :: use_polygonal_tundra = .false.
+  logical, public :: uniform_polygonal_tundra = .false.
   logical, public :: prohibit_subsidence  = .false.
   logical, public :: use_arctic_init      = .false.
 

--- a/components/elm/src/main/elm_varctl.F90
+++ b/components/elm/src/main/elm_varctl.F90
@@ -410,7 +410,7 @@ module elm_varctl
   ! NGEE Arctic parameterizations
   !----------------------------------------------------------
   logical, public :: use_polygonal_tundra = .false.
-  logical, public :: uniform_polygonal_tundra = .false.
+  logical, public :: unified_polygonal_tundra = .false.
   logical, public :: prohibit_subsidence  = .false.
   logical, public :: use_arctic_init      = .false.
 

--- a/components/elm/src/main/histFileMod.F90
+++ b/components/elm/src/main/histFileMod.F90
@@ -1988,7 +1988,7 @@ contains
     !
     ! !USES:
     use landunit_varcon, only : max_lunit, max_non_poly_lunit, landunit_names, landunit_name_length
-    use elm_varctl,      only : use_polygonal_tundra
+    use elm_varctl,      only : use_polygonal_tundra, unified_polygonal_tundra
     !
     ! !ARGUMENTS:
     type(file_desc_t), intent(inout) :: lnfid ! local file id
@@ -2002,10 +2002,17 @@ contains
     !-----------------------------------------------------------------------
     
     if (use_polygonal_tundra) then
-      do ltype = 1, max_lunit
-        attname = att_prefix // landunit_names(ltype)
-        call ncd_putatt(lnfid, ncd_global, attname, ltype)
-      end do
+      if (unified_polygonal_tundra) then
+         do ltype = 1, max_lunit
+            attname = att_prefix // landunit_names(ltype)
+            call ncd_putatt(lnfid, ncd_global, attname, ltype)
+         end do
+      else
+         do ltype = 1, max_lunit -1 
+            attname = att_prefix // landunit_names(ltype)
+            call ncd_putatt(lnfid, ncd_global, attname, ltype)
+         end do
+      end if
     else
       do ltype = 1, max_non_poly_lunit
         attname = att_prefix // landunit_names(ltype)

--- a/components/elm/src/main/initGridCellsMod.F90
+++ b/components/elm/src/main/initGridCellsMod.F90
@@ -341,7 +341,7 @@ contains
     use elm_varsur, only : wt_lunit, wt_nat_patch, wt_polygon
     use subgridMod, only : subgrid_get_topounitinfo
     use elm_varpar, only : numpft, maxpatch_pft, numcft, natpft_lb, natpft_ub, natpft_size
-    use landunit_varcon, only: istlowcenpoly, istflatcenpoly, isthighcenpoly, max_non_poly_lunit
+    use landunit_varcon, only: istlowcenpoly, istflatcenpoly, isthighcenpoly, istunifiedpoly, max_non_poly_lunit
     !
     ! !ARGUMENTS:    
     integer , intent(in)    :: ltype             ! landunit type

--- a/components/elm/src/main/initGridCellsMod.F90
+++ b/components/elm/src/main/initGridCellsMod.F90
@@ -13,7 +13,7 @@ module initGridCellsMod
   use spmdMod        , only : masterproc,iam
   use abortutils     , only : endrun
   use elm_varctl     , only : iulog
-  use elm_varctl     , only : use_fates, use_fates_sp, use_polygonal_tundra
+  use elm_varctl     , only : use_fates, use_fates_sp, use_polygonal_tundra, unified_polygonal_tundra
   use elm_varcon     , only : namep, namec, namel, nameg
   use decompMod      , only : bounds_type, ldecomp
   use GridcellType   , only : grc_pp
@@ -405,21 +405,39 @@ contains
        ! continue to assume one column per landunit.
        if (use_polygonal_tundra) then
          ! loop over polygon types:
-         do z = istlowcenpoly,isthighcenpoly
-           ! get new weight for wttopounit:
-           wtpoly2lndunit = wt_lunit(gi, topo_ind, z) 
-           call add_polygon_landunit(li=li, ti=ti, ltype=ltype, wttopounit=wtpoly2lndunit, polytype = z - max_non_poly_lunit)
-           call add_column(ci=ci, li=li, ctype=1, wtlunit=1.0_r8)
-           ! add patch:
-           do m = natpft_lb,natpft_ub
-             if(use_fates .and. .not.use_fates_sp) then
-               p_wt = 1.0_r8/real(natpft_size,r8)
-             else
-               p_wt = wt_nat_patch(gi,topo_ind,m)
-             end if
-             call add_patch(pi=pi, ci=ci, ptype=m, wtcol=p_wt)
+         if (unified_polygonal_tundra) then
+           do z = istlowcenpoly,istunifiedpoly
+            ! get new weight for wttopounit:
+            wtpoly2lndunit = wt_lunit(gi, topo_ind, z) 
+            call add_polygon_landunit(li=li, ti=ti, ltype=ltype, wttopounit=wtpoly2lndunit, polytype = z - max_non_poly_lunit)
+            call add_column(ci=ci, li=li, ctype=1, wtlunit=1.0_r8)
+            ! add patch:
+            do m = natpft_lb,natpft_ub
+               if(use_fates .and. .not.use_fates_sp) then
+                  p_wt = 1.0_r8/real(natpft_size,r8)
+               else
+                  p_wt = wt_nat_patch(gi,topo_ind,m)
+               end if
+               call add_patch(pi=pi, ci=ci, ptype=m, wtcol=p_wt)
+            end do
            end do
-         end do
+         else
+            do z = istlowcenpoly,isthighcenpoly
+               ! get new weight for wttopounit:
+               wtpoly2lndunit = wt_lunit(gi, topo_ind, z) 
+               call add_polygon_landunit(li=li, ti=ti, ltype=ltype, wttopounit=wtpoly2lndunit, polytype = z - (max_non_poly_lunit - 1))
+               call add_column(ci=ci, li=li, ctype=1, wtlunit=1.0_r8)
+               ! add patch:
+               do m = natpft_lb,natpft_ub
+                  if(use_fates .and. .not.use_fates_sp) then
+                     p_wt = 1.0_r8/real(natpft_size,r8)
+                  else
+                     p_wt = wt_nat_patch(gi,topo_ind,m)
+                  end if
+                  call add_patch(pi=pi, ci=ci, ptype=m, wtcol=p_wt)
+               end do
+            end do
+         endif
        end if 
 
     end if

--- a/components/elm/src/main/initGridCellsMod.F90
+++ b/components/elm/src/main/initGridCellsMod.F90
@@ -233,6 +233,7 @@ contains
        ! Fill in subgrid datatypes
 
        call elm_ptrs_compdown(bounds_clump)
+       call set_unified_polygon_degradation(bounds_clump)
 
        ! By putting this check within the loop over clumps, we ensure that (for example)
        ! if a clump is responsible for landunit L, then that same clump is also
@@ -457,6 +458,7 @@ contains
     use column_varcon   , only : icemec_class_to_col_itype
     use subgridMod      , only : subgrid_get_topounitinfo
     use pftvarcon       , only : noveg
+    use elm_varctl      , only : unified_polygonal_tundra
 
     !
     ! !ARGUMENTS:    
@@ -501,14 +503,19 @@ contains
 
     wtlunit2topounit = wt_lunit(gi,topo_ind, ltype)
 
-    if (npfts > 0) then
+    if (npfts > 0 .or. &
+         (ltype == istdlak .and. unified_polygonal_tundra .and. wtlunit2topounit > 0._r8)) then
 
-       if (npfts /=1 .and. ltype /= istice_mec) then
-          write(iulog,*)' set_landunit_wet_ice_lake: landunit must'// &
-               ' have one pft '
-          write(iulog,*)' current value of npfts=',npfts
-          write(iulog,*)' landunit type = ',ltype
-          call endrun(msg=errMsg(__FILE__, __LINE__))
+       if (ltype /= istice_mec) then
+          if (ltype == istdlak .and. unified_polygonal_tundra) then
+             ! For unified-polygon runs, allow lake creation based on weight even if
+             ! subgrid_get_topounitinfo returns nlake = 0.
+          else if (npfts /= 1) then
+             write(iulog,*)' set_landunit_wet_ice_lake: landunit must have one pft '
+             write(iulog,*)' current value of npfts=',npfts
+             write(iulog,*)' landunit type = ',ltype
+             call endrun(msg=errMsg(__FILE__, __LINE__))
+          end if
        end if
 
        if (ltype==istice_mec) then   ! multiple columns per landunit
@@ -538,14 +545,14 @@ contains
 
           ! Currently assume that each landunit only has only one column 
           ! and that each column has its own pft
-       
+
           call add_landunit(li=li, ti=ti, ltype=ltype, wttopounit=wtlunit2topounit)
           call add_column(ci=ci, li=li, ctype=ltype, wtlunit=1.0_r8)
           call add_patch(pi=pi, ci=ci, ptype=noveg, wtcol=1.0_r8)
 
        end if   ! ltype = istice_mec
     endif       ! npfts > 0       
-
+    
   end subroutine set_landunit_wet_ice_lake
 
   !------------------------------------------------------------------------
@@ -1343,5 +1350,40 @@ contains
   end subroutine CheckGhostSubgridHierarchy
 #endif
 !^ifdef USE_PETSC_LIB
+
+  subroutine set_unified_polygon_degradation(bounds)
+   use shr_kind_mod   , only : r8 => shr_kind_r8
+    use elm_varctl     , only : use_polygonal_tundra, unified_polygonal_tundra
+    use elm_varsur     , only : wt_polygon
+    use landunit_varcon, only : istsoil, istunifiedpoly
+    use landunit_varcon, only : istunifiedpoly, iflatcenpoly, ihighcenpoly
+    use ColumnDataType , only : col_ws
+    use LandunitType   , only : lun_pp
+    use decompMod      , only : bounds_type
+
+    implicit none
+
+    type(bounds_type), intent(in) :: bounds
+    integer :: l, c
+    real(r8) :: degval
+
+    if (.not. use_polygonal_tundra) return
+    if (.not. unified_polygonal_tundra) return
+
+    do l = bounds%begl, bounds%endl
+       if (lun_pp%itype(l) == istunifiedpoly) then
+
+          ! Current fallback behavior matches earlier intent:
+          ! 0*LCP + 0.5*FCP + 1.0*HCP
+          degval = 0.5_r8 * wt_polygon(lun_pp%gridcell(l), lun_pp%topounit(l), iflatcenpoly) + &
+                   1.0_r8 * wt_polygon(lun_pp%gridcell(l), lun_pp%topounit(l), ihighcenpoly)
+
+          do c = lun_pp%coli(l), lun_pp%colf(l)
+             col_ws%degradation_index(c) = degval
+          end do
+       end if
+    end do
+
+  end subroutine set_unified_polygon_degradation
 
 end module initGridCellsMod

--- a/components/elm/src/main/initVerticalMod.F90
+++ b/components/elm/src/main/initVerticalMod.F90
@@ -19,6 +19,7 @@ module initVerticalMod
   use elm_varctl     , only : use_vancouver, use_mexicocity, use_vertsoilc, use_extralakelayers, use_extrasnowlayers
   use elm_varctl     , only : use_erosion, use_polygonal_tundra
   use elm_varcon     , only : zlak, dzlak, zsoi, dzsoi, zisoi, dzsoi_decomp, spval, grlnd
+  use histFileMod    , only : hist_addfld2d
   use column_varcon  , only : icol_roof, icol_sunwall, icol_shadewall, icol_road_perv, icol_road_imperv
   use landunit_varcon, only : istdlak, istice_mec
   use fileutils      , only : getfil
@@ -77,9 +78,10 @@ contains
     real(r8), allocatable :: dzurb_roof(:,:)   ! roof (layer thickness)
     real(r8), allocatable :: ziurb_wall(:,:)   ! wall (layer interface)
     real(r8), allocatable :: ziurb_roof(:,:)   ! roof (layer interface)
-    real(r8)              :: depthratio        ! ratio of lake depth to standard deep lake depth 
+    real(r8)              :: depthratio        ! ratio of lake depth to standard deep lake depth
     integer               :: begc, endc
     integer               :: begl, endl
+    real(r8), pointer     :: data2dptr(:,:)    ! temp. pointer for slicing snow+soil arrays
     !------------------------------------------------------------------------
 
     begc = bounds%begc; endc= bounds%endc
@@ -334,11 +336,13 @@ contains
              col_pp%z(c,1:nlevgrnd)  = zsoi(1:nlevgrnd)
              col_pp%zi(c,0:nlevgrnd) = zisoi(0:nlevgrnd)
              col_pp%dz(c,1:nlevgrnd) = dzsoi(1:nlevgrnd)
+             col_pp%dz_ref(c,1:nlevgrnd) = dzsoi(1:nlevgrnd)
           end if
        else if (lun_pp%itype(l) /= istdlak) then
           col_pp%z(c,1:nlevgrnd)  = zsoi(1:nlevgrnd)
           col_pp%zi(c,0:nlevgrnd) = zisoi(0:nlevgrnd)
           col_pp%dz(c,1:nlevgrnd) = dzsoi(1:nlevgrnd)
+          col_pp%dz_ref(c,1:nlevgrnd) = dzsoi(1:nlevgrnd)
        end if
     end do
 
@@ -464,6 +468,7 @@ contains
           col_pp%z(c,1:nlevgrnd)  = zsoi(1:nlevgrnd)
           col_pp%zi(c,0:nlevgrnd) = zisoi(0:nlevgrnd)
           col_pp%dz(c,1:nlevgrnd) = dzsoi(1:nlevgrnd)
+          col_pp%dz_ref(c,1:nlevgrnd) = dzsoi(1:nlevgrnd)
        end if
     end do
 
@@ -703,6 +708,14 @@ contains
          slope0 = slopemax**(-1._r8/slopebeta)
          col_pp%micro_sigma(c) = (col_pp%topo_slope(c) + slope0)**(-slopebeta)
       end do
+
+    !-----------------------------------------------
+    ! Register history field for deformed soil layer thickness
+    !-----------------------------------------------
+    data2dptr => col_pp%dz(:,1:nlevgrnd)
+    call hist_addfld2d (fname='DZ_SOIL', units='m', type2d='levgrnd', avgflag='A', &
+         long_name='Soil layer thickness (deformed by excess ice where present)', &
+         ptr_col=data2dptr, l2g_scale_type='veg', default='inactive')
 
     call ncd_pio_closefile(ncid)
 

--- a/components/elm/src/main/initVerticalMod.F90
+++ b/components/elm/src/main/initVerticalMod.F90
@@ -343,6 +343,7 @@ contains
           col_pp%zi(c,0:nlevgrnd) = zisoi(0:nlevgrnd)
           col_pp%dz(c,1:nlevgrnd) = dzsoi(1:nlevgrnd)
           col_pp%dz_ref(c,1:nlevgrnd) = dzsoi(1:nlevgrnd)
+          col_pp%volrat(c,1:nlevgrnd) = 1._r8
        end if
     end do
 

--- a/components/elm/src/main/landunit_varcon.F90
+++ b/components/elm/src/main/landunit_varcon.F90
@@ -6,7 +6,7 @@ module landunit_varcon
   !
   ! !USES:
 #include "shr_assert.h"
-    use elm_varctl, only : use_polygonal_tundra
+    use elm_varctl, only : use_polygonal_tundra, unified_polygonal_tundra
   !
   !
   ! !PUBLIC TYPES:

--- a/components/elm/src/main/landunit_varcon.F90
+++ b/components/elm/src/main/landunit_varcon.F90
@@ -33,8 +33,9 @@ module landunit_varcon
   integer, parameter, public :: istlowcenpoly  = 10 ! low centered polygon landunit type
   integer, parameter, public :: istflatcenpoly = 11 ! flat cenetered polygon landunit type
   integer, parameter, public :: isthighcenpoly = 12 ! high centered polygon landunit type
+  integer, parameter, public :: istunifiedpoly = 13 ! unified polygon landunit type (temporary while phasing over to new parameterization)
 
-  integer, parameter, public :: max_lunit  = 12  !maximum value that lun_pp%itype can have
+  integer, parameter, public :: max_lunit  = 13  !maximum value that lun_pp%itype can have
                                         !(i.e., largest value in the above list)
   integer, parameter, public :: max_non_poly_lunit = 9 ! maximum non-polygonal tundra land unit
 
@@ -45,8 +46,9 @@ module landunit_varcon
   integer, parameter, public :: ilowcenpoly     = 1     ! low-centered polygons
   integer, parameter, public :: iflatcenpoly    = 2     ! flat-centered polygons
   integer, parameter, public :: ihighcenpoly    = 3     ! high-centered polygons
+  integer, parameter, public :: iunifiedpoly    = 4     ! unified polygons (temporary while phasing over to new parameterization)
 
-  integer, parameter, public :: max_polygon = 3  !maximum value that lun_pp%polygontype can have
+  integer, parameter, public :: max_polygon = 4  !maximum value that lun_pp%polygontype can have
                                                  !(i.e., largest value in the above list)
 
   integer, parameter, public                   :: polygon_name_length = 40  ! max length of landunit names
@@ -135,6 +137,7 @@ contains
     polygon_names(ilowcenpoly) = 'low_centered_polygons'
     polygon_names(iflatcenpoly) = 'flat_centered_polygons'
     polygon_names(ihighcenpoly) = 'high_centered_polygons'
+    polygon_names(iunifiedpoly) = 'unified_polygons'
 
     if (any(polygon_names == not_set)) then
        call shr_sys_abort(trim(subname)//': Not all polygon names set')
@@ -157,7 +160,11 @@ contains
     !-----------------------------------------------------------------------
 
     if (use_polygonal_tundra) then
-      allocate(landunit_names(max_lunit))
+      if (unified_polygonal_tundra) then
+        allocate(landunit_names(max_lunit))
+      else
+        allocate(landunit_names(max_lunit - 1))
+      end if
     else
       allocate(landunit_names(max_non_poly_lunit))
     end if
@@ -177,6 +184,9 @@ contains
       landunit_names(istlowcenpoly) = 'low_centered_polygon'
       landunit_names(istflatcenpoly) = 'flat_centered_polygon'
       landunit_names(isthighcenpoly) = 'high_centered_polygon'
+      if (unified_polygonal_tundra) then
+        landunit_names(istunifiedpoly) = 'unified_polygon'
+      end if
     end if
 
     if (any(landunit_names == not_set)) then

--- a/components/elm/src/main/restFileMod.F90
+++ b/components/elm/src/main/restFileMod.F90
@@ -17,7 +17,9 @@ module restFileMod
   use elm_varpar           , only : crop_prog
   use elm_varctl           , only : use_cn, use_c13, use_c14, use_lch4, use_fates, use_betr
   use elm_varctl           , only : use_erosion
-  use elm_varctl           , only : create_glacier_mec_landunit, iulog 
+  use elm_varctl           , only : create_glacier_mec_landunit, iulog
+  use elm_varctl           , only : use_polygonal_tundra
+  use ExcessIceMod         , only : inflate_layers_from_excess_ice
   use elm_varcon           , only : c13ratio, c14ratio
   use elm_varcon           , only : nameg, namet, namel, namec, namep, nameCohort
   use CH4Mod               , only : ch4_type
@@ -580,6 +582,11 @@ contains
 
     call col_ws%Restart (bounds, ncid, flag='read', &
          watsat_input=soilstate_vars%watsat_col(bounds%begc:bounds%endc,:))
+
+    ! After reading restart, inflate soil layer geometry to match restored excess ice
+    if (use_polygonal_tundra) then
+       call inflate_layers_from_excess_ice(bounds)
+    end if
 
     call veg_ws%Restart (bounds, ncid, flag='read')
 

--- a/components/elm/src/main/subgridMod.F90
+++ b/components/elm/src/main/subgridMod.F90
@@ -40,7 +40,7 @@ contains
     !
     ! !USES
     use elm_varpar  , only : natpft_size, cft_size, maxpatch_urb, maxpatch_glcmec
-    use elm_varctl  , only : create_crop_landunit, use_polygonal_tundra
+    use elm_varctl  , only : create_crop_landunit, use_polygonal_tundra, unified_polygonal_tundra
     use elm_varsur  , only : wt_lunit, urban_valid, wt_glc_mec
     use landunit_varcon  , only : istsoil, istcrop, istice, istice_mec, istdlak, istwet, &
                              isturb_tbd, isturb_hd, isturb_md
@@ -161,11 +161,20 @@ contains
 
        ! polygonal tundra
        if (use_polygonal_tundra) then
-         ilunits = ilunits + 3
-         icols = icols + 3
-         ipfts = ipfts + 3 * npfts_per_lunit
-         ! if (present(nveg)) nveg = nveg + 3 * npfts_per_lunit
+          if (unified_polygonal_tundra) then
+             ! Unified-polygon runs still build 4 polygon-related natural landunits/columns
+             ! in addition to the base natural soil landunit.
+             ilunits = ilunits + 4
+             icols   = icols + 4
+             ipfts   = ipfts + 4 * npfts_per_lunit
+          else
+             ilunits = ilunits + 3
+             icols   = icols + 3
+             ipfts   = ipfts + 3 * npfts_per_lunit
+          end if
+          ! if (present(nveg)) nveg = nveg + ...
        endif
+
        ! -------------------------------------------------------------------------
        ! Set urban landunits
        ! -------------------------------------------------------------------------
@@ -341,7 +350,7 @@ contains
     !
     ! !USES
     use elm_varpar  , only : natpft_size, cft_size, maxpatch_urb, maxpatch_glcmec
-    use elm_varctl  , only : create_crop_landunit, use_polygonal_tundra
+    use elm_varctl  , only : create_crop_landunit, use_polygonal_tundra, unified_polygonal_tundra
     use elm_varsur  , only : wt_lunit, urban_valid, wt_glc_mec
     use landunit_varcon  , only : istsoil, istcrop, istice, istice_mec, istdlak, istwet, &
                              isturb_tbd, isturb_hd, isturb_md
@@ -432,13 +441,19 @@ contains
 
     ! -----------------------------------------------------------------------
     ! polygonal tundra
-
-    ! polygonal tundra
     if (use_polygonal_tundra) then
-      ilunits = ilunits + 3
-      icols = icols + 3
-      ipfts = ipfts + 3 * npfts_per_lunit
-      ! if (present(nveg)) nveg = nveg + 3 * npfts_per_lunit
+       if (unified_polygonal_tundra) then
+          ! Unified-polygon runs still build 4 polygon-related natural landunits/columns
+          ! in addition to the base natural soil landunit.
+          ilunits = ilunits + 4
+          icols   = icols + 4
+          ipfts   = ipfts + 4 * npfts_per_lunit
+       else
+          ilunits = ilunits + 3
+          icols   = icols + 3
+          ipfts   = ipfts + 3 * npfts_per_lunit
+       end if
+       ! if (present(nveg)) nveg = nveg + 3 * npfts_per_lunit
     endif
 
     ! -------------------------------------------------------------------------

--- a/components/elm/src/main/surfrdMod.F90
+++ b/components/elm/src/main/surfrdMod.F90
@@ -10,7 +10,7 @@ module surfrdMod
   use shr_log_mod     , only : errMsg => shr_log_errMsg
   use abortutils      , only : endrun
   use elm_varpar      , only : nlevsoifl, numpft, numcft
-  use landunit_varcon , only : numurbl
+  use landunit_varcon , only : numurbl, max_lunit, max_non_poly_lunit
   use elm_varcon      , only : grlnd
   use elm_varctl      , only : iulog, scmlat, scmlon, single_column, firrig_data
   use elm_varctl      , only : create_glacier_mec_landunit
@@ -1143,7 +1143,7 @@ contains
          if (.not. readvar) write(iulog,*) "WARNING: no input degradation index, so setting to weighted average of polygon types as: 0*PCT_LCP + 0.5*PCT_FCP + 1.0*PCT_HCP"
          do g = begg, endg
             do t = grc_pp%topi(g), grc_pp%topf(g)
-               do l = max_non_poly_landunit, max_lunit
+               do l = max_non_poly_lunit, max_lunit
                   do c = lun_pp%coli(l),lun_pp%colf(l)
                      ! initialize to zero rather than spval
                      col_ws%degradation_index(c) = 0._r8

--- a/components/elm/src/main/surfrdMod.F90
+++ b/components/elm/src/main/surfrdMod.F90
@@ -1142,16 +1142,18 @@ contains
             dim1name=grlnd, readvar=readvar)
          if (.not. readvar) write(iulog,*) "WARNING: no input degradation index, so setting to weighted average of polygon types as: 0*PCT_LCP + 0.5*PCT_FCP + 1.0*PCT_HCP"
          do g = begg, endg
-            do c = grc_pp%coli(g), grc_pp%colf(g)
-               ! initialize to zero rather than spval
-               col_ws%degradation_index(c) = 0._r8
-               l = col_pp%landunit(c)
-               t = col_pp%topounit(c)
-               if (l .eq. iflatcenpoly) then
-                  col_ws%degradation_index(c) = 0.5_r8*wt_polygon(g,t,iflatcenpoly)/100._r8
-               else if (l .eq. ihighcenpoly) then
-                  col_ws%degradation_index(c) = col_ws%degradation_index(c) + wt_polygon(g,t,ihighcenpoly)/100_r8
-               endif
+            do t = grc_pp%topi(g), grc_pp%topf(g)
+               do l = max_non_poly_landunit, max_lunit
+                  do c = lun_pp%coli(l),lun_pp%colf(l)
+                     ! initialize to zero rather than spval
+                     col_ws%degradation_index(c) = 0._r8
+                     if (l .eq. iflatcenpoly) then
+                        col_ws%degradation_index(c) = 0.5_r8*wt_polygon(g,t,iflatcenpoly)/100._r8
+                     else if (l .eq. ihighcenpoly) then
+                        col_ws%degradation_index(c) = wt_polygon(g,t,ihighcenpoly)/100_r8
+                     endif
+                  end do
+               end do
             enddo
          enddo
          wt_polygon(begg:endg,1:max_topounits,iunifiedpoly) = wt_polygon(begg:endg,1:max_topounits,ihighcenpoly) + &
@@ -1324,7 +1326,8 @@ contains
           wt_lunit(nl,t,istlowcenpoly) = wt_lunit(nl,t,istsoil) * wt_polygon(nl,t,ilowcenpoly)
           wt_lunit(nl,t,istflatcenpoly) = wt_lunit(nl,t,istsoil) * wt_polygon(nl,t,iflatcenpoly)
           wt_lunit(nl,t,isthighcenpoly) = wt_lunit(nl,t,istsoil) * wt_polygon(nl,t,ihighcenpoly)
-          wt_lunit(nl,t,istsoil) = wt_lunit(nl,t,istsoil) - sum(wt_lunit(nl,t,istlowcenpoly:isthighcenpoly))
+          wt_lunit(nl,t,istunifiedpoly) = wt_lunit(nl,t,istsoil) * wt_polygon(nl,t,iunifiedpoly)
+          wt_lunit(nl,t,istsoil) = wt_lunit(nl,t,istsoil) - sum(wt_lunit(nl,t,istlowcenpoly:istunifiedpoly))
           ! check to make sure istsoil weight is still positive:
           if (wt_lunit(nl,t,istsoil) .lt. 0_r8) then
             call endrun(msg='ERROR:Polygonal tundra fraction > 100% in surface file'//&

--- a/components/elm/src/main/surfrdMod.F90
+++ b/components/elm/src/main/surfrdMod.F90
@@ -1129,6 +1129,14 @@ contains
          dim1name=grlnd, readvar=readvar)
       if (.not. readvar) call endrun( msg=' ERROR: use_polygonal_tundra = .true., but PCT_LCP NOT on surfdata file'//errMsg(__FILE__, __LINE__))
       wt_polygon(begg:endg,1:max_topounits,ilowcenpoly) = arrayl(begg:endg,1:max_topounits)
+      if (unified_polygonal_tundra) then
+         wt_polygon(begg:endg,1:max_topounits,iunifiedpoly) = wt_polygon(begg:endg,1:max_topounits,ihighcenpoly) + &
+              wt_polygon(begg:endg,1:max_topounits,iflatcenpoly) + &
+              wt_polygon(begg:endg,1:max_topounits,ilowcenpoly)
+         wt_polygon(begg:endg,1:max_topounits,ihighcenpoly) = 0._r8
+         wt_polygon(begg:endg,1:max_topounits,iflatcenpoly) = 0._r8
+         wt_polygon(begg:endg,1:max_topounits,ilowcenpoly) = 0._r8
+      endif
     else
       wt_polygon(begg:endg,1:max_topounits,ilowcenpoly:ihighcenpoly) = 0._r8
     endif

--- a/components/elm/src/main/surfrdMod.F90
+++ b/components/elm/src/main/surfrdMod.F90
@@ -1072,6 +1072,7 @@ contains
     use elm_varpar      , only : surfpft_lb, surfpft_ub, surfpft_size, cft_lb, cft_ub, cft_size
     use elm_varpar      , only : crop_prog
     use elm_varsur      , only : wt_lunit, wt_nat_patch, wt_cft, fert_cft, fert_p_cft, wt_polygon
+    use ColumnDataType  , only : col_ws ! temporary!
     use landunit_varcon , only : istsoil, istcrop
     use landunit_varcon , only : istlowcenpoly, ilowcenpoly, istflatcenpoly, iflatcenpoly, isthighcenpoly, ihighcenpoly
     use pftvarcon       , only : nc3crop, nc3irrig, npcropmin
@@ -1130,6 +1131,12 @@ contains
       if (.not. readvar) call endrun( msg=' ERROR: use_polygonal_tundra = .true., but PCT_LCP NOT on surfdata file'//errMsg(__FILE__, __LINE__))
       wt_polygon(begg:endg,1:max_topounits,ilowcenpoly) = arrayl(begg:endg,1:max_topounits)
       if (unified_polygonal_tundra) then
+
+         call ncd_io(ncid=ncid, varname='DEGRADATION_INDEX', flag='read', data=arrayl, &
+            dim1name=grlnd, readvar=readvar)
+         if (.not. readvar) write(iulog,*) "WARNING: no input degradation index, so setting to weighted average of polygon types as: 0*PCT_LCP + 0.5*PCT_FCP + 1.0*PCT_HCP"
+         col_ws%degradation_index(begg:endg) = (0.5_r8*wt_polygon(begg:endg,1:max_topounits,iflatcenpoly) + &
+              wt_polygon(begg:endg,1:max_topounits,ihighcenpoly))/100_r8
          wt_polygon(begg:endg,1:max_topounits,iunifiedpoly) = wt_polygon(begg:endg,1:max_topounits,ihighcenpoly) + &
               wt_polygon(begg:endg,1:max_topounits,iflatcenpoly) + &
               wt_polygon(begg:endg,1:max_topounits,ilowcenpoly)

--- a/components/elm/src/main/surfrdMod.F90
+++ b/components/elm/src/main/surfrdMod.F90
@@ -1067,14 +1067,19 @@ contains
     ! Determine weight arrays for non-dynamic landuse mode
     !
     ! !USES:
-    use elm_varctl      , only : create_crop_landunit, use_fates, use_polygonal_tundra
+    use elm_varctl      , only : create_crop_landunit, use_fates, use_polygonal_tundra, unified_polygonal_tundra
     use elm_varctl      , only : irrigate
     use elm_varpar      , only : surfpft_lb, surfpft_ub, surfpft_size, cft_lb, cft_ub, cft_size
     use elm_varpar      , only : crop_prog
     use elm_varsur      , only : wt_lunit, wt_nat_patch, wt_cft, fert_cft, fert_p_cft, wt_polygon
     use ColumnDataType  , only : col_ws ! temporary!
+    use GridCellType    , only : grc_pp
+    use TopounitType    , only : top_pp
+    use LandUnitType    , only : lun_pp
+    use ColumnType      , only : col_pp
     use landunit_varcon , only : istsoil, istcrop
     use landunit_varcon , only : istlowcenpoly, ilowcenpoly, istflatcenpoly, iflatcenpoly, isthighcenpoly, ihighcenpoly
+    use landunit_varcon , only : istunifiedpoly, iunifiedpoly
     use pftvarcon       , only : nc3crop, nc3irrig, npcropmin
     use pftvarcon       , only : ncorn, ncornirrig, nsoybean, nsoybeanirrig
     use pftvarcon       , only : nscereal, nscerealirrig, nwcereal, nwcerealirrig
@@ -1091,7 +1096,7 @@ contains
     integer          ,intent(in)    :: ntpu(:)
     !
     ! !LOCAL VARIABLES:
-    integer  :: nl, t                             ! index
+    integer  :: nl, t, c, l, g                 ! indices
     integer  :: dimid,varid                    ! netCDF id's
     integer  :: ier                            ! error status	
     integer  :: cftsize                        ! size of CFT's
@@ -1102,6 +1107,7 @@ contains
     real(r8),pointer :: arrayNF(:,:,:)
     real(r8),pointer :: arrayPF(:,:,:)
     character(len=32) :: subname = 'surfrd_veg_all'  ! subroutine name
+    integer :: begc, endc
 !-----------------------------------------------------------------------
 
     call check_dim(ncid, 'lsmpft', numpft+1)
@@ -1135,8 +1141,19 @@ contains
          call ncd_io(ncid=ncid, varname='DEGRADATION_INDEX', flag='read', data=arrayl, &
             dim1name=grlnd, readvar=readvar)
          if (.not. readvar) write(iulog,*) "WARNING: no input degradation index, so setting to weighted average of polygon types as: 0*PCT_LCP + 0.5*PCT_FCP + 1.0*PCT_HCP"
-         col_ws%degradation_index(begg:endg) = (0.5_r8*wt_polygon(begg:endg,1:max_topounits,iflatcenpoly) + &
-              wt_polygon(begg:endg,1:max_topounits,ihighcenpoly))/100_r8
+         do g = begg, endg
+            do c = grc_pp%coli(g), grc_pp%colf(g)
+               ! initialize to zero rather than spval
+               col_ws%degradation_index(c) = 0._r8
+               l = col_pp%landunit(c)
+               t = col_pp%topounit(c)
+               if (l .eq. iflatcenpoly) then
+                  col_ws%degradation_index(c) = 0.5_r8*wt_polygon(g,t,iflatcenpoly)/100._r8
+               else if (l .eq. ihighcenpoly) then
+                  col_ws%degradation_index(c) = col_ws%degradation_index(c) + wt_polygon(g,t,ihighcenpoly)/100_r8
+               endif
+            enddo
+         enddo
          wt_polygon(begg:endg,1:max_topounits,iunifiedpoly) = wt_polygon(begg:endg,1:max_topounits,ihighcenpoly) + &
               wt_polygon(begg:endg,1:max_topounits,iflatcenpoly) + &
               wt_polygon(begg:endg,1:max_topounits,ilowcenpoly)

--- a/components/elm/src/main/surfrdMod.F90
+++ b/components/elm/src/main/surfrdMod.F90
@@ -607,7 +607,7 @@ contains
     call ncd_io(ncid=ncid, varname= 'PFTDATA_MASK', flag='read', data=ldomain%pftm, &
          dim1name=grlnd, readvar=readvar)
     if (.not. readvar) call endrun( msg=' ERROR: pftm NOT on surface dataset'//errMsg(__FILE__, __LINE__))
-	        
+	 
     !! Read the actual number of topounits per grid    
 	!call check_var(ncid=ncid, varname='topoPerGrid', vardesc=vardesc, readvar=readvar)
     !if (readvar) then
@@ -672,7 +672,7 @@ contains
     ! Obtain special landunit info
 
     call surfrd_special(begg, endg, ncid, ldomain%ns,ldomain%num_tunits_per_grd)
-    
+
     ! Obtain vegetated landunit info
 
     call surfrd_veg_all(begg, endg, ncid, ldomain%ns,ldomain%num_tunits_per_grd)
@@ -1120,13 +1120,13 @@ contains
          dim1name=grlnd, readvar=readvar)
     if (.not. readvar) call endrun( msg=' ERROR: PCT_NATVEG NOT on surfdata file'//errMsg(__FILE__, __LINE__))
     wt_lunit(begg:endg,1:max_topounits,istsoil) = arrayl(begg:endg,1:max_topounits)
-
+    
     if (use_polygonal_tundra) then
       call ncd_io(ncid=ncid, varname='PCT_HCP', flag='read', data=arrayl, &
          dim1name=grlnd, readvar=readvar)
       if (.not. readvar) call endrun( msg=' ERROR: use_polygonal_tundra = .true., but PCT_HCP NOT on surfdata file'//errMsg(__FILE__, __LINE__))
       wt_polygon(begg:endg,1:max_topounits,ihighcenpoly) = arrayl(begg:endg,1:max_topounits)
-
+      
       call ncd_io(ncid=ncid, varname='PCT_FCP', flag='read', data=arrayl, &
          dim1name=grlnd, readvar=readvar)
       if (.not. readvar) call endrun( msg=' ERROR: use_polygonal_tundra = .true., but PCT_FCP NOT on surfdata file'//errMsg(__FILE__, __LINE__))
@@ -1141,27 +1141,10 @@ contains
          call ncd_io(ncid=ncid, varname='DEGRADATION_INDEX', flag='read', data=arrayl, &
             dim1name=grlnd, readvar=readvar)
          if (.not. readvar) write(iulog,*) "WARNING: no input degradation index, so setting to weighted average of polygon types as: 0*PCT_LCP + 0.5*PCT_FCP + 1.0*PCT_HCP"
-         do g = begg, endg
-            do t = grc_pp%topi(g), grc_pp%topf(g)
-               do l = max_non_poly_lunit, max_lunit
-                  do c = lun_pp%coli(l),lun_pp%colf(l)
-                     ! initialize to zero rather than spval
-                     col_ws%degradation_index(c) = 0._r8
-                     if (l .eq. iflatcenpoly) then
-                        col_ws%degradation_index(c) = 0.5_r8*wt_polygon(g,t,iflatcenpoly)/100._r8
-                     else if (l .eq. ihighcenpoly) then
-                        col_ws%degradation_index(c) = wt_polygon(g,t,ihighcenpoly)/100_r8
-                     endif
-                  end do
-               end do
-            enddo
-         enddo
          wt_polygon(begg:endg,1:max_topounits,iunifiedpoly) = wt_polygon(begg:endg,1:max_topounits,ihighcenpoly) + &
               wt_polygon(begg:endg,1:max_topounits,iflatcenpoly) + &
               wt_polygon(begg:endg,1:max_topounits,ilowcenpoly)
-         wt_polygon(begg:endg,1:max_topounits,ihighcenpoly) = 0._r8
-         wt_polygon(begg:endg,1:max_topounits,iflatcenpoly) = 0._r8
-         wt_polygon(begg:endg,1:max_topounits,ilowcenpoly) = 0._r8
+     
       endif
     else
       wt_polygon(begg:endg,1:max_topounits,ilowcenpoly:ihighcenpoly) = 0._r8
@@ -1175,7 +1158,7 @@ contains
     wt_lunit(begg:endg,1:max_topounits,istcrop) = arrayl(begg:endg,1:max_topounits) 
 
     deallocate(arrayl)
-    
+
     ! Check the file format for CFT's and handle accordingly
     call ncd_inqdid(ncid, 'cft', dimid, cft_dim_exists)
     if ( cft_dim_exists .and. create_crop_landunit ) then
@@ -1323,11 +1306,25 @@ contains
       ! adjust wt_lunit(:,:,istsoil) for polygonal fraction:
       do nl = begg,endg
         do t = 1,max_topounits
-          wt_lunit(nl,t,istlowcenpoly) = wt_lunit(nl,t,istsoil) * wt_polygon(nl,t,ilowcenpoly)
-          wt_lunit(nl,t,istflatcenpoly) = wt_lunit(nl,t,istsoil) * wt_polygon(nl,t,iflatcenpoly)
-          wt_lunit(nl,t,isthighcenpoly) = wt_lunit(nl,t,istsoil) * wt_polygon(nl,t,ihighcenpoly)
-          wt_lunit(nl,t,istunifiedpoly) = wt_lunit(nl,t,istsoil) * wt_polygon(nl,t,iunifiedpoly)
-          wt_lunit(nl,t,istsoil) = wt_lunit(nl,t,istsoil) - sum(wt_lunit(nl,t,istlowcenpoly:istunifiedpoly))
+          if (unified_polygonal_tundra) then
+            wt_lunit(nl,t,istlowcenpoly)  = 0._r8
+            wt_lunit(nl,t,istflatcenpoly) = 0._r8
+            wt_lunit(nl,t,isthighcenpoly) = 0._r8
+            wt_lunit(nl,t,istunifiedpoly) = wt_lunit(nl,t,istsoil) * wt_polygon(nl,t,iunifiedpoly)
+
+            wt_lunit(nl,t,istsoil) = wt_lunit(nl,t,istsoil) - wt_lunit(nl,t,istunifiedpoly)
+          else
+            wt_lunit(nl,t,istlowcenpoly) = wt_lunit(nl,t,istsoil) * wt_polygon(nl,t,ilowcenpoly)
+            wt_lunit(nl,t,istflatcenpoly) = wt_lunit(nl,t,istsoil) * wt_polygon(nl,t,iflatcenpoly)
+            wt_lunit(nl,t,isthighcenpoly) = wt_lunit(nl,t,istsoil) * wt_polygon(nl,t,ihighcenpoly)
+            wt_lunit(nl,t,istunifiedpoly) = 0._r8
+
+            wt_lunit(nl,t,istsoil) = wt_lunit(nl,t,istsoil) - &
+             ( wt_lunit(nl,t,istlowcenpoly) + &
+               wt_lunit(nl,t,istflatcenpoly) + &
+               wt_lunit(nl,t,isthighcenpoly) )
+          end if
+          
           ! check to make sure istsoil weight is still positive:
           if (wt_lunit(nl,t,istsoil) .lt. 0_r8) then
             call endrun(msg='ERROR:Polygonal tundra fraction > 100% in surface file'//&


### PR DESCRIPTION
## Summary

This PR fixes several issues in the unified polygon pathway in ELM that were causing initialization failures and a later segmentation fault when unified degradation logic was enabled.

## Background

While testing unified polygon runs, initialization initially failed because the subgrid structure and associated weights were not being set consistently for unified polygon cases. After fixing those issues, enabling the unified degradation logic still caused a segmentation fault, indicating that degradation-index assignment was occurring before the relevant model structures were fully ready.

## What changed

- updated initialization in `elm_initializeMod.F90` to ensure required arrays are allocated / initialized correctly for unified polygon runs
- corrected unified polygon setup logic in `initGridCellsMod.F90`
- adjusted supporting subgrid logic in `subgridMod.F90`
- revised `surfrdMod.F90` so unified degradation-index handling is applied at a safer point in the initialization sequence

With these updates:
- unified polygon runs initialize successfully
- degradation-index logic no longer triggers the previous segmentation fault
- non-unified behavior is intended to remain unchanged

## Files changed

- `components/elm/src/main/elm_initializeMod.F90`
- `components/elm/src/main/initGridCellsMod.F90`
- `components/elm/src/main/subgridMod.F90`
- `components/elm/src/main/surfrdMod.F90`