### PR TITLE
Add ELM soil freezing and thermal conductivity variables to history output

### DIFF
--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -2272,6 +2272,7 @@ this mask will have smb calculated over the entire global land surface
 
 <!-- NGEE Arctic Options -->
 <use_polygonal_tundra>.false.</use_polygonal_tundra>;
+<prohibit_subsidence>.false.</prohibit_subsidence>;
 <use_arctic_init>.false.</use_arctic_init>;
 
 </namelist_defaults>

--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -2259,16 +2259,6 @@ default: 0
 </entry>
 
 <!-- ========================================================================================  -->
-<!-- NGEE Arctic Options                                                                       -->
-<!-- ========================================================================================  -->
-
-<entry id="use_arctic_init" type="logical" category="default_settings"
-	group="elm_inparm" value=".false.">
-Cold-start initialization conditions in tundra start saturated and frozen.
-<default>Default: .false.</default>
-</entry>
-
-<!-- ========================================================================================  -->
 <!-- Namelist options for soil erosion model                                                   -->
 <!-- ========================================================================================  -->
 
@@ -2337,6 +2327,18 @@ not be called.
 <entry id="use_polygonal_tundra" type="logical" category="default_settings"
 	group="elm_inparm" value=".false.">
 Use polygonal tundra parameterizations for ice wedge polygon microtopography and inindation fraction
+<default>Default: .false.</default>
+</entry>
+
+<entry id="prohibit_subsidence" type="logical" category="default_settings"
+       group="elm_inparm" value=".false.">
+Prohibit microtopographic changes associated with subsidence in ice wedge polygons
+<default>Default: .false.</default>
+</entry>
+
+<entry id="use_arctic_init" type="logical" category="default_settings"
+	group="elm_inparm" value=".false.">
+Cold-start initialization conditions in tundra start saturated and frozen.
 <default>Default: .false.</default>
 </entry>
 

--- a/components/elm/src/biogeophys/ActiveLayerMod.F90
+++ b/components/elm/src/biogeophys/ActiveLayerMod.F90
@@ -7,7 +7,7 @@ module ActiveLayerMod
   ! !USES:
   use shr_kind_mod    , only : r8 => shr_kind_r8
   use shr_const_mod   , only : SHR_CONST_TKFRZ
-  use elm_varctl      , only : iulog, spinup_state, use_polygonal_tundra, allow_subsidence
+  use elm_varctl      , only : iulog, spinup_state, use_polygonal_tundra, prohibit_subsidence
   use TemperatureType , only : temperature_type
   use CanopyStateType , only : canopystate_type
   use GridcellType    , only : grc_pp       

--- a/components/elm/src/biogeophys/ActiveLayerMod.F90
+++ b/components/elm/src/biogeophys/ActiveLayerMod.F90
@@ -7,7 +7,7 @@ module ActiveLayerMod
   ! !USES:
   use shr_kind_mod    , only : r8 => shr_kind_r8
   use shr_const_mod   , only : SHR_CONST_TKFRZ
-  use elm_varctl      , only : iulog, spinup_state, use_polygonal_tundra
+  use elm_varctl      , only : iulog, spinup_state, use_polygonal_tundra, allow_subsidence
   use TemperatureType , only : temperature_type
   use CanopyStateType , only : canopystate_type
   use GridcellType    , only : grc_pp       
@@ -172,7 +172,7 @@ contains
             endif
          endif
 
-         if (use_polygonal_tundra) then
+         if (use_polygonal_tundra .and. .not. prohibit_subsidence) then
             ! special case for year = 1989. For now it is the assumed baseline year for 
             ! changes in polygonal ground
             if (year .eq. 1989) then

--- a/components/elm/src/biogeophys/SoilHydrologyMod.F90
+++ b/components/elm/src/biogeophys/SoilHydrologyMod.F90
@@ -576,7 +576,7 @@ contains
              if (lun_pp%ispolygon(col_pp%landunit(c))) then
                 vdep = (2_r8*iwp_exclvol(c) - iwp_microrel(c)) * (iwp_ddep(c)/iwp_microrel(c))**3_r8 &
                        + (2_r8*iwp_microrel(c) - 3_r8*iwp_exclvol(c)) * (iwp_ddep(c)/iwp_microrel(c))**2_r8
-                phi_eff = min(iwp_subsidence(c), 0.4_r8)  !fix this variable when available to pull from alt calculations
+                phi_eff = min(iwp_subsidence(c), 0.4_r8)  !possibly redundant w/ ActiveLayerMod
                 swc = h2osfc(c)/1000_r8 ! convert to m
                 
                 if (swc >= vdep) then

--- a/components/elm/src/biogeophys/SoilHydrologyMod.F90
+++ b/components/elm/src/biogeophys/SoilHydrologyMod.F90
@@ -425,7 +425,10 @@ contains
           i_0                  =>    soilhydrology_vars%i_0_col              , & ! Input:  [real(r8) (:)   ]  column average soil moisture in top VIC layers (mm)
           h2osfcflag           =>    soilhydrology_vars%h2osfcflag           , & ! Input:  logical
           pc_grid              =>    soilhydrology_vars%pc                   , & ! Input:  [real(r8) (:)   ]  threshold for outflow from surface water storage
-          icefrac              =>    soilhydrology_vars%icefrac_col            & ! Output: [real(r8) (:,:) ]  fraction of ice
+          icefrac              =>    soilhydrology_vars%icefrac_col          , & ! Output: [real(r8) (:,:) ]  fraction of ice
+
+          ! RPF debug, would be helpful to also keep the h2osfc from the previous time step
+          h2osfc_p             =>   col_ws%h2osfc_p                           & ! Input? Really for debugging to see if time aliasing causes spread in IM1 issues
               )
 
 
@@ -447,6 +450,9 @@ contains
           l = col_pp%landunit(c)
           pc = pc_grid(g)
           
+         ! before doing anything, preserve h2osfc:
+          h2osfc_p(c) = h2osfc(c)
+
           ! partition moisture fluxes between soil and h2osfc
           if (col_pp%is_soil(c) .or. col_pp%is_crop(c)) then
 

--- a/components/elm/src/biogeophys/SoilHydrologyMod.F90
+++ b/components/elm/src/biogeophys/SoilHydrologyMod.F90
@@ -426,9 +426,7 @@ contains
           h2osfcflag           =>    soilhydrology_vars%h2osfcflag           , & ! Input:  logical
           pc_grid              =>    soilhydrology_vars%pc                   , & ! Input:  [real(r8) (:)   ]  threshold for outflow from surface water storage
           icefrac              =>    soilhydrology_vars%icefrac_col          , & ! Output: [real(r8) (:,:) ]  fraction of ice
-
-          ! RPF debug, would be helpful to also keep the h2osfc from the previous time step
-          h2osfc_p             =>   col_ws%h2osfc_p                           & ! Input? Really for debugging to see if time aliasing causes spread in IM1 issues
+          h2osfc_p             =>    col_ws%h2osfc_p                           & ! Input:  [real(r8) (:,:) ]  h2osfc from previous timestep
               )
 
 
@@ -582,7 +580,7 @@ contains
              if (lun_pp%ispolygon(col_pp%landunit(c))) then
                 vdep = (2_r8*iwp_exclvol(c) - iwp_microrel(c)) * (iwp_ddep(c)/iwp_microrel(c))**3_r8 &
                        + (2_r8*iwp_microrel(c) - 3_r8*iwp_exclvol(c)) * (iwp_ddep(c)/iwp_microrel(c))**2_r8
-                phi_eff = min(iwp_subsidence(c), 0.4_r8)  !possibly redundant w/ ActiveLayerMod
+                phi_eff = min(iwp_subsidence(c), 0.4_r8)
                 swc = h2osfc(c)/1000_r8 ! convert to m
                 
                 if (swc >= vdep) then

--- a/components/elm/src/biogeophys/SoilStateType.F90
+++ b/components/elm/src/biogeophys/SoilStateType.F90
@@ -72,6 +72,7 @@ module SoilStateType
 
   !!!   ! thermal conductivity / heat capacity
      real(r8), pointer :: thk_col              (:,:) ! col thermal conductivity of each layer [W/m-K]
+     real(r8), pointer :: tk_h2osfc_col        (:)   ! col thermal conductivity of surface water [W/(m K)]
      real(r8), pointer :: tkmg_col             (:,:) ! col thermal conductivity, soil minerals  [W/m-K] (new) (nlevgrnd)
      real(r8), pointer :: tkdry_col            (:,:) ! col thermal conductivity, dry soil (W/m/Kelvin) (nlevgrnd)
      real(r8), pointer :: tksatu_col           (:,:) ! col thermal conductivity, saturated soil [W/m-K] (new) (nlevgrnd)
@@ -175,6 +176,7 @@ contains
     allocate(this%gwc_thr_col          (begc:endc))                     ; this%gwc_thr_col          (:)   = spval
 
     allocate(this%thk_col              (begc:endc,-nlevsno+1:nlevgrnd)) ; this%thk_col              (:,:) = spval
+    allocate(this%tk_h2osfc_col        (begc:endc))                     ; this%tk_h2osfc_col        (:)   = spval
     allocate(this%tkmg_col             (begc:endc,nlevgrnd))            ; this%tkmg_col             (:,:) = spval
     allocate(this%tkdry_col            (begc:endc,nlevgrnd))            ; this%tkdry_col            (:,:) = spval
     allocate(this%tksatu_col           (begc:endc,nlevgrnd))            ; this%tksatu_col           (:,:) = spval
@@ -280,6 +282,17 @@ contains
     call hist_addfld2d (fname='SNO_TK', units='W/m-K', type2d='levsno', &
          avgflag='A', long_name='Thermal conductivity', &
          ptr_col=data2dptr, no_snow_behavior=no_snow_normal, default='inactive')
+
+    this%thk_col(begc:endc,1:nlevgrnd) = spval
+    data2dptr => this%thk_col(:,1:nlevgrnd)
+    call hist_addfld2d (fname='TK', units='W/m-K', type2d='levgrnd', &
+         avgflag='A', long_name='Thermal conductivity at soil layer centers', &
+         ptr_col=data2dptr, l2g_scale_type='veg', default='inactive')
+
+    this%tk_h2osfc_col(begc:endc) = spval
+    call hist_addfld1d (fname='TK_H2OSFC', units='W/(m K)', &
+         avgflag='A', long_name='Thermal conductivity of surface water', &
+         ptr_col=this%tk_h2osfc_col, default='inactive')
 
     this%hk_l_col(begc:endc,:) = spval
     call hist_addfld2d (fname='HK',  units='mm/s', type2d='levgrnd',  &

--- a/components/elm/src/biogeophys/SoilTemperatureMod.F90
+++ b/components/elm/src/biogeophys/SoilTemperatureMod.F90
@@ -1029,7 +1029,13 @@ contains
               /(tkwat*z(c,1)+thk(c,1)*zh2osfc)
       enddo
 
-      ! Soil heat capacity, from de Vires (1963)
+      ! Save surface water thermal conductivity for history output
+      do fc = 1, num_nolakec
+         c = filter_nolakec(fc)
+         soilstate_vars%tk_h2osfc_col(c) = tk_h2osfc(c)
+      enddo
+
+      ! Soil heat capacity, from de Vries (1963)
       ! Urban values are from Masson et al. 2002, Evaluation of the Town Energy Balance (TEB)
       ! scheme with direct measurements from dry districts in two cities, J. Appl. Meteorol.,
       ! 41, 1011-1026.

--- a/components/elm/src/biogeophys/SoilTemperatureMod.F90
+++ b/components/elm/src/biogeophys/SoilTemperatureMod.F90
@@ -1392,7 +1392,6 @@ contains
          fact             =>    col_es%fact                         , &
 
          imelt            =>    col_ef%imelt          , & ! Output: [integer  (:,:) ] flag for melting (=1), freezing (=2), Not=0 (new)
-         imelt_hist       =>    col_ef%imelt_hist     , &
          tinc             =>    col_ef%tinc           , & ! Output: [real(r8) (:,:) ] phase-change temperature increment, t(n+1)-t(n) (K)
          t_soisno         =>    col_es%t_soisno         & ! Output: [real(r8) (:,:) ] soil temperature (Kelvin)
          )
@@ -1420,7 +1419,6 @@ contains
 
                ! Initialization
                imelt(c,j) = 0
-               imelt_hist(c,j) = real(imelt(c,j), r8)
                tinc(c,j)     = 0._r8
                hm(c,j) = 0._r8
                xm(c,j) = 0._r8

--- a/components/elm/src/biogeophys/SoilTemperatureMod.F90
+++ b/components/elm/src/biogeophys/SoilTemperatureMod.F90
@@ -1340,10 +1340,10 @@ contains
     real(r8) :: wmass0(bounds%begc:bounds%endc,-nlevsno+1:nlevgrnd)!initial mass of ice and liquid (kg/m2)
     real(r8) :: wice0 (bounds%begc:bounds%endc,-nlevsno+1:nlevgrnd)!initial mass of ice (kg/m2)
     real(r8) :: wliq0 (bounds%begc:bounds%endc,-nlevsno+1:nlevgrnd)!initial mass of liquid (kg/m2)
-    real(r8) :: supercool(bounds%begc:bounds%endc,nlevgrnd)        !supercooled water in soil (kg/m2)
+    !real(r8) :: supercool(bounds%begc:bounds%endc,nlevgrnd)        !supercooled water in soil (kg/m2)
     real(r8) :: propor                             !proportionality constant (-)
     real(r8) :: tinc(bounds%begc:bounds%endc,-nlevsno+1:nlevgrnd)  !t(n+1)-t(n) (K)
-    real(r8) :: smp                                !frozen water potential (mm)
+    !real(r8) :: smp                                !frozen water potential (mm)
     
     character(len=64) :: event 
     !-----------------------------------------------------------------------
@@ -1365,6 +1365,8 @@ contains
          h2osno           =>    col_ws%h2osno          , & ! Output: [real(r8) (:)   ] snow water (mm H2O)
          h2osoi_liq       =>    col_ws%h2osoi_liq      , & ! Output: [real(r8) (:,:) ] liquid water (kg/m2) (new)
          h2osoi_ice       =>    col_ws%h2osoi_ice      , & ! Output: [real(r8) (:,:) ] ice lens (kg/m2) (new)
+         smp_i            =>    col_ws%smp_i           , & ! Output: [real(r8) (:,:) ] frozen water potential (mm)
+         supercool        =>    col_ws%supercool       , & ! Output: [real(r8) (:,:) ] supercooled water (kg/m2)
 
          qflx_snow_melt   =>    col_wf%qflx_snow_melt   , & ! Output: [real(r8) (:)   ] net snow melt
          qflx_snofrz_lyr  =>    col_wf%qflx_snofrz_lyr  , & ! Output: [real(r8) (:,:) ] snow freezing rate (positive definite) (col,lyr) [kg m-2 s-1]
@@ -1469,8 +1471,8 @@ contains
                supercool(c,j) = 0.0_r8
                if (col_pp%is_soil(c) .or. col_pp%is_crop(c) .or. col_pp%itype(c) == icol_road_perv) then
                   if(t_soisno(c,j) < tfrz) then
-                     smp = hfus*(tfrz-t_soisno(c,j))/(grav*t_soisno(c,j)) * 1000._r8  !(mm)
-                     supercool(c,j) = watsat(c,j)*(smp/sucsat(c,j))**(-1._r8/bsw(c,j))
+                     smp_i = hfus*(tfrz-t_soisno(c,j))/(grav*t_soisno(c,j)) * 1000._r8  !(mm)
+                     supercool(c,j) = watsat(c,j)*(smp_i/sucsat(c,j))**(-1._r8/bsw(c,j))
                      supercool(c,j) = supercool(c,j)*dz(c,j)*1000._r8       ! (mm)
                   endif
                endif

--- a/components/elm/src/biogeophys/SoilTemperatureMod.F90
+++ b/components/elm/src/biogeophys/SoilTemperatureMod.F90
@@ -1118,7 +1118,7 @@ contains
     real(r8) :: hm(bounds%begc:bounds%endc) !energy residual [W/m2                         ]
     real(r8) :: xm(bounds%begc:bounds%endc) !melting or freezing within a time step [kg/m2 ]
     real(r8) :: tinc                        !t(n+1)-t(n) (K)
-    real(r8) :: smp                         !frozen water potential (mm)
+    !real(r8) :: smp                         !frozen water potential (mm)
     real(r8) :: rho_avg
     real(r8) :: z_avg
     real(r8) :: c1
@@ -1477,8 +1477,8 @@ contains
                supercool(c,j) = 0.0_r8
                if (col_pp%is_soil(c) .or. col_pp%is_crop(c) .or. col_pp%itype(c) == icol_road_perv) then
                   if(t_soisno(c,j) < tfrz) then
-                     smp_i = hfus*(tfrz-t_soisno(c,j))/(grav*t_soisno(c,j)) * 1000._r8  !(mm)
-                     supercool(c,j) = watsat(c,j)*(smp_i/sucsat(c,j))**(-1._r8/bsw(c,j))
+                     smp_i(c,j) = hfus*(tfrz-t_soisno(c,j))/(grav*t_soisno(c,j)) * 1000._r8  !(mm)
+                     supercool(c,j) = watsat(c,j)*(smp_i(c,j)/sucsat(c,j))**(-1._r8/bsw(c,j))
                      supercool(c,j) = supercool(c,j)*dz(c,j)*1000._r8       ! (mm)
                   endif
                endif

--- a/components/elm/src/biogeophys/SoilTemperatureMod.F90
+++ b/components/elm/src/biogeophys/SoilTemperatureMod.F90
@@ -1388,6 +1388,7 @@ contains
          fact             =>    col_es%fact                         , &
 
          imelt            =>    col_ef%imelt          , & ! Output: [integer  (:,:) ] flag for melting (=1), freezing (=2), Not=0 (new)
+         tinc             =>    col_ef%tinc           , & ! Output: [real(r8) (:,:) ] phase-change temperature increment, t(n+1)-t(n) (K)
          t_soisno         =>    col_es%t_soisno         & ! Output: [real(r8) (:,:) ] soil temperature (Kelvin)
          )
 

--- a/components/elm/src/biogeophys/SoilTemperatureMod.F90
+++ b/components/elm/src/biogeophys/SoilTemperatureMod.F90
@@ -1348,7 +1348,7 @@ contains
     real(r8) :: wliq0 (bounds%begc:bounds%endc,-nlevsno+1:nlevgrnd)!initial mass of liquid (kg/m2)
     !real(r8) :: supercool(bounds%begc:bounds%endc,nlevgrnd)        !supercooled water in soil (kg/m2)
     real(r8) :: propor                             !proportionality constant (-)
-    real(r8) :: tinc(bounds%begc:bounds%endc,-nlevsno+1:nlevgrnd)  !t(n+1)-t(n) (K)
+   !  real(r8) :: tinc(bounds%begc:bounds%endc,-nlevsno+1:nlevgrnd)  !t(n+1)-t(n) (K)
     !real(r8) :: smp                                !frozen water potential (mm)
     
     character(len=64) :: event 
@@ -1392,6 +1392,8 @@ contains
          fact             =>    col_es%fact                         , &
 
          imelt            =>    col_ef%imelt          , & ! Output: [integer  (:,:) ] flag for melting (=1), freezing (=2), Not=0 (new)
+         imelt_hist       =>    col_ef%imelt_hist     , &
+         tinc             =>    col_ef%tinc           , & ! Output: [real(r8) (:,:) ] phase-change temperature increment, t(n+1)-t(n) (K)
          t_soisno         =>    col_es%t_soisno         & ! Output: [real(r8) (:,:) ] soil temperature (Kelvin)
          )
 
@@ -1418,6 +1420,8 @@ contains
 
                ! Initialization
                imelt(c,j) = 0
+               imelt_hist(c,j) = real(imelt(c,j), r8)
+               tinc(c,j)     = 0._r8
                hm(c,j) = 0._r8
                xm(c,j) = 0._r8
                wice0(c,j) = h2osoi_ice(c,j)

--- a/components/elm/src/biogeophys/SoilTemperatureMod.F90
+++ b/components/elm/src/biogeophys/SoilTemperatureMod.F90
@@ -1118,7 +1118,6 @@ contains
     real(r8) :: hm(bounds%begc:bounds%endc) !energy residual [W/m2                         ]
     real(r8) :: xm(bounds%begc:bounds%endc) !melting or freezing within a time step [kg/m2 ]
     real(r8) :: tinc                        !t(n+1)-t(n) (K)
-    !real(r8) :: smp                         !frozen water potential (mm)
     real(r8) :: rho_avg
     real(r8) :: z_avg
     real(r8) :: c1
@@ -1346,10 +1345,7 @@ contains
     real(r8) :: wmass0(bounds%begc:bounds%endc,-nlevsno+1:nlevgrnd)!initial mass of ice and liquid (kg/m2)
     real(r8) :: wice0 (bounds%begc:bounds%endc,-nlevsno+1:nlevgrnd)!initial mass of ice (kg/m2)
     real(r8) :: wliq0 (bounds%begc:bounds%endc,-nlevsno+1:nlevgrnd)!initial mass of liquid (kg/m2)
-    !real(r8) :: supercool(bounds%begc:bounds%endc,nlevgrnd)        !supercooled water in soil (kg/m2)
     real(r8) :: propor                             !proportionality constant (-)
-   !  real(r8) :: tinc(bounds%begc:bounds%endc,-nlevsno+1:nlevgrnd)  !t(n+1)-t(n) (K)
-    !real(r8) :: smp                                !frozen water potential (mm)
     
     character(len=64) :: event 
     !-----------------------------------------------------------------------
@@ -1392,7 +1388,6 @@ contains
          fact             =>    col_es%fact                         , &
 
          imelt            =>    col_ef%imelt          , & ! Output: [integer  (:,:) ] flag for melting (=1), freezing (=2), Not=0 (new)
-         tinc             =>    col_ef%tinc           , & ! Output: [real(r8) (:,:) ] phase-change temperature increment, t(n+1)-t(n) (K)
          t_soisno         =>    col_es%t_soisno         & ! Output: [real(r8) (:,:) ] soil temperature (Kelvin)
          )
 

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -442,7 +442,6 @@ module ColumnDataType
     real(r8), pointer :: xmf                     (:)   => null() ! total latent heat of phase change of ground water
     real(r8), pointer :: xmf_h2osfc              (:)   => null() ! latent heat of phase change of surface water
     integer , pointer :: imelt                   (:,:) => null() ! flag for melting (=1), freezing (=2), Not=0 (-nlevsno+1:nlevgrnd)
-    real(r8), pointer :: imelt_hist              (:,:) => null()
     real(r8), pointer :: tinc                    (:,:) => null() ! phase-change temperature increment tfrz - t_soisno (K) (-nlevsno+1:nlevgrnd)
     ! for couplig with pflotran
     real(r8), pointer :: eflx_soil_grnd          (:)   => null() ! integrated soil ground heat flux (W/m2)  [+ = into ground]
@@ -5701,7 +5700,6 @@ contains
     allocate(this%xmf                  (begc:endc))              ; this%xmf                  (:)   = spval
     allocate(this%xmf_h2osfc           (begc:endc))              ; this%xmf_h2osfc           (:)   = spval
     allocate(this%imelt                (begc:endc,-nlevsno+1:nlevgrnd))  ; this%imelt        (:,:) = huge(1)
-    allocate(this%imelt_hist(begc:endc,-nlevsno+1:nlevgrnd))     ; this%imelt_hist           (:,:) = spval
     allocate(this%tinc                 (begc:endc,-nlevsno+1:nlevgrnd))  ; this%tinc         (:,:) = spval
   
     allocate(this%eflx_soil_grnd       (begc:endc))              ; this%eflx_soil_grnd       (:)   = spval
@@ -5782,11 +5780,6 @@ contains
           avgflag='A', long_name='phase-change temperature increment before resetting layer to freezing point', &
           ptr_col=this%tinc, default='inactive')
 
-    this%imelt(begc:endc,:) = 0
-     call hist_addfld2d (fname='IMELT', units='flag', type2d='levgrnd', &
-          avgflag='A', long_name='phase-change flag: 0 none, 1 melt, 2 freeze', &
-          ptr_col=this%imelt_hist, default='inactive')
-
     this%errsoi(begc:endc) = spval
      call hist_addfld1d (fname='ERRSOI',  units='W/m^2',  &
           avgflag='A', long_name='soil/lake energy conservation error', &
@@ -5808,7 +5801,6 @@ contains
        end if
     end do
 
-    this%imelt_hist(begc:endc,:) = 0._r8
     this%tinc(begc:endc,:)  = 0._r8
 
   end subroutine col_ef_init

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -442,6 +442,8 @@ module ColumnDataType
     real(r8), pointer :: xmf                     (:)   => null() ! total latent heat of phase change of ground water
     real(r8), pointer :: xmf_h2osfc              (:)   => null() ! latent heat of phase change of surface water
     integer , pointer :: imelt                   (:,:) => null() ! flag for melting (=1), freezing (=2), Not=0 (-nlevsno+1:nlevgrnd)
+    real(r8), pointer :: imelt_hist              (:,:) => null()
+    real(r8), pointer :: tinc                    (:,:) => null() ! phase-change temperature increment tfrz - t_soisno (K) (-nlevsno+1:nlevgrnd)
     ! for couplig with pflotran
     real(r8), pointer :: eflx_soil_grnd          (:)   => null() ! integrated soil ground heat flux (W/m2)  [+ = into ground]
     real(r8), pointer :: eflx_rnet_soil          (:)   => null() ! soil net (sw+lw) radiation flux (W/m2) [+ = into soil]
@@ -5699,6 +5701,9 @@ contains
     allocate(this%xmf                  (begc:endc))              ; this%xmf                  (:)   = spval
     allocate(this%xmf_h2osfc           (begc:endc))              ; this%xmf_h2osfc           (:)   = spval
     allocate(this%imelt                (begc:endc,-nlevsno+1:nlevgrnd))  ; this%imelt        (:,:) = huge(1)
+    allocate(this%imelt_hist(begc:endc,-nlevsno+1:nlevgrnd))     ; this%imelt_hist           (:,:) = spval
+    allocate(this%tinc                 (begc:endc,-nlevsno+1:nlevgrnd))  ; this%tinc         (:,:) = spval
+  
     allocate(this%eflx_soil_grnd       (begc:endc))              ; this%eflx_soil_grnd       (:)   = spval
     allocate(this%eflx_rnet_soil       (begc:endc))              ; this%eflx_rnet_soil       (:)   = spval
     allocate(this%eflx_fgr0_soil       (begc:endc))              ; this%eflx_fgr0_soil       (:)   = spval
@@ -5752,6 +5757,36 @@ contains
           avgflag='A', long_name='Rural downward heat flux at interface below each soil layer', &
            ptr_col=this%eflx_fgr, set_spec=spval, default='inactive')
 
+    this%eflx_fgr12(begc:endc) = spval
+     call hist_addfld1d (fname='FGR0_SOIL',  units='W/m^2',  &
+          avgflag='A', long_name='soil-air heat flux (W/m2) [+ = into soil]', &
+           ptr_col=this%eflx_fgr0_soil, set_lake=spval, default='inactive')
+
+    this%eflx_fgr12(begc:endc) = spval
+     call hist_addfld1d (fname='FGR0_SNOW',  units='W/m^2',  &
+          avgflag='A', long_name='soil-snow heat flux (W/m2) [+ = into soil]', &
+           ptr_col=this%eflx_fgr0_snow, set_lake=spval, default='inactive')
+
+    this%eflx_fgr12(begc:endc) = spval
+     call hist_addfld1d (fname='FGR0_H2OSFC',  units='W/m^2',  &
+          avgflag='A', long_name='soil-surfacewater heat flux (W/m2) [+ = into soil]', &
+           ptr_col=this%eflx_fgr0_h2osfc, set_lake=spval, default='inactive')
+
+    this%xmf(begc:endc) = spval
+     call hist_addfld1d (fname='XMF', units='W/m^2',  &
+          avgflag='A', long_name='total latent heat flux from soil/snow phase change', &
+          ptr_col=this%xmf, default='inactive')
+
+    this%tinc(begc:endc,:) = spval
+     call hist_addfld2d (fname='TINC', units='K', type2d='levgrnd', &
+          avgflag='A', long_name='phase-change temperature increment before resetting layer to freezing point', &
+          ptr_col=this%tinc, default='inactive')
+
+    this%imelt(begc:endc,:) = 0
+     call hist_addfld2d (fname='IMELT', units='flag', type2d='levgrnd', &
+          avgflag='A', long_name='phase-change flag: 0 none, 1 melt, 2 freeze', &
+          ptr_col=this%imelt_hist, default='inactive')
+
     this%errsoi(begc:endc) = spval
      call hist_addfld1d (fname='ERRSOI',  units='W/m^2',  &
           avgflag='A', long_name='soil/lake energy conservation error', &
@@ -5772,6 +5807,9 @@ contains
           this%eflx_urban_heat(c)    = 0._r8
        end if
     end do
+
+    this%imelt_hist(begc:endc,:) = 0._r8
+    this%tinc(begc:endc,:)  = 0._r8
 
   end subroutine col_ef_init
 

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -178,7 +178,7 @@ module ColumnDataType
     real(r8), pointer :: iwp_subsidence   (:) => null() ! ice wedge polygon ground subsidence (m)
     real(r8), pointer :: excess_ice     (:,:) => null() ! excess ground ice in column (1:nlevgrnd) (0 to 1)
     real(r8), pointer :: frac_melted    (:,:) => null() ! fraction of layer that has ever thawed (for tracking excess ice removal) (0 to 1)
-    real(r8), pointer :: h2osfc_p         (:) => null() ! h2osfc from previous timestep (inundataion fraction is calculated based on this var)
+    real(r8), pointer :: h2osfc_p         (:) => null() ! h2osfc from previous timestep (inundation fraction is calculated based on this var)
     real(r8), pointer :: supercool      (:,:) => null() ! supercooled liquid water in soil (kg/m2)
     real(r8), pointer :: smp_i          (:,:) => null() ! frozen water potential
   contains
@@ -1411,6 +1411,7 @@ contains
     allocate(this%h2osoi_ice         (begc:endc,-nlevsno+1:nlevgrnd)) ; this%h2osoi_ice         (:,:) = spval
     allocate(this%h2osoi_vol         (begc:endc, 1:nlevgrnd))         ; this%h2osoi_vol         (:,:) = spval
     allocate(this%h2osfc             (begc:endc))                     ; this%h2osfc             (:)   = spval
+    allocate(this%h2osfc_p           (begc:endc))                     ; this%h2osfc_p           (:)   = spval
     allocate(this%h2ocan             (begc:endc))                     ; this%h2ocan             (:)   = spval
     allocate(this%wslake_col         (begc:endc))                     ; this%wslake_col         (:)   = spval
     allocate(this%total_plant_stored_h2o(begc:endc))                  ; this%total_plant_stored_h2o(:)= spval  
@@ -1468,6 +1469,8 @@ contains
     allocate(this%h2orof             (begc:endc))                     ; this%h2orof             (:)   = spval
     allocate(this%frac_h2orof        (begc:endc))                     ; this%frac_h2orof        (:)   = spval
     allocate(this%frac_h2oocn        (begc:endc))                     ; this%frac_h2oocn        (:)   = nan
+    allocate(this%supercool          (begc:endc,1:nlevgrnd))          ; this%supercool        (:,:)   = spval
+    allocate(this%smp_i              (begc:endc,1:nlevgrnd))          ; this%smp_i            (:,:)   = spval
     if (use_polygonal_tundra) then
       ! polygonal tundra/ice wedge polygons:
       allocate(this%iwp_microrel       (begc:endc))                   ; this%iwp_microrel     (:) = spval

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -442,8 +442,7 @@ module ColumnDataType
     real(r8), pointer :: xmf                     (:)   => null() ! total latent heat of phase change of ground water
     real(r8), pointer :: xmf_h2osfc              (:)   => null() ! latent heat of phase change of surface water
     integer , pointer :: imelt                   (:,:) => null() ! flag for melting (=1), freezing (=2), Not=0 (-nlevsno+1:nlevgrnd)
-    real(r8), pointer :: tinc                    (:,:) => null() ! phase-change temperature increment tfrz - t_soisno (K) (-nlevsno+1:nlevgrnd)
-    ! for couplig with pflotran
+    ! for coupling with pflotran
     real(r8), pointer :: eflx_soil_grnd          (:)   => null() ! integrated soil ground heat flux (W/m2)  [+ = into ground]
     real(r8), pointer :: eflx_rnet_soil          (:)   => null() ! soil net (sw+lw) radiation flux (W/m2) [+ = into soil]
     real(r8), pointer :: eflx_fgr0_soil          (:)   => null() ! soil-air heat flux (W/m2) [+ = into soil]

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -178,6 +178,7 @@ module ColumnDataType
     real(r8), pointer :: iwp_subsidence   (:) => null() ! ice wedge polygon ground subsidence (m)
     real(r8), pointer :: excess_ice     (:,:) => null() ! excess ground ice in column (1:nlevgrnd) (0 to 1)
     real(r8), pointer :: frac_melted    (:,:) => null() ! fraction of layer that has ever thawed (for tracking excess ice removal) (0 to 1)
+    real(r8), pointer :: h2osfc_p         (:) => null() !!! DEBUG
 
   contains
     procedure, public :: Init    => col_ws_init
@@ -1409,6 +1410,8 @@ contains
     allocate(this%h2osoi_ice         (begc:endc,-nlevsno+1:nlevgrnd)) ; this%h2osoi_ice         (:,:) = spval
     allocate(this%h2osoi_vol         (begc:endc, 1:nlevgrnd))         ; this%h2osoi_vol         (:,:) = spval
     allocate(this%h2osfc             (begc:endc))                     ; this%h2osfc             (:)   = spval
+    ! DEBUG
+    allocate(this%h2osfc_p           (begc:endc))                     ; this%h2osfc_p           (:)   = spval
     allocate(this%h2ocan             (begc:endc))                     ; this%h2ocan             (:)   = spval
     allocate(this%wslake_col         (begc:endc))                     ; this%wslake_col         (:)   = spval
     allocate(this%total_plant_stored_h2o(begc:endc))                  ; this%total_plant_stored_h2o(:)= spval  
@@ -1540,6 +1543,11 @@ contains
      call hist_addfld1d (fname='H2OSFC',  units='mm',  &
           avgflag='A', long_name='surface water depth', &
            ptr_col=this%h2osfc)
+
+    this%h2osfc(begc:endc) = spval
+     call hist_addfld1d (fname='H2OSFC_P', units = 'mm',  &
+          avgflag='A', long_name='surface water depth previous time step', &
+           ptr_col=this%h2osfc_p)
 
     this%h2osoi_vol(begc:endc,:) = spval
      call hist_addfld2d (fname='H2OSOI',  units='mm3/mm3', type2d='levgrnd', &
@@ -1690,6 +1698,7 @@ contains
        this%wf2(c)                    = spval
        this%total_plant_stored_h2o(c) = 0._r8
        this%h2osfc(c)                 = 0._r8
+       this%h2osfc_p(c)               = 0._r8 ! DEBUG
        this%h2ocan(c)                 = 0._r8
        this%frac_h2osfc(c)            = 0._r8
        this%frac_h2osfc_act(c)        = 0._r8
@@ -1901,6 +1910,15 @@ contains
          interpinic_flag='interp', readvar=readvar, data=this%h2osfc)
     if (flag=='read' .and. .not. readvar) then
        this%h2osfc(bounds%begc:bounds%endc) = 0.0_r8
+    end if
+
+    ! DEBUG
+    call restartvar(ncid=ncid, flag=flag, varname='H2OSFC_P', xtype=ncd_double,  &
+         dim1name='column', &
+         long_name='surface water', units='kg/m2', &
+         interpinic_flag='interp', readvar=readvar, data=this%h2osfc_p)
+    if (flag=='read' .and. .not. readvar) then
+       this%h2osfc_p(bounds%begc:bounds%endc) = 0.0_r8
     end if
 
     if(do_budgets) then 

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -1,4 +1,4 @@
-module ColumnDataType
+   module ColumnDataType
 
   !-----------------------------------------------------------------------
   ! !DESCRIPTION:
@@ -181,7 +181,7 @@ module ColumnDataType
     real(r8), pointer :: frac_melted    (:,:) => null() ! fraction of layer that has ever thawed (for tracking excess ice removal) (0 to 1)
     real(r8), pointer :: h2osfc_p         (:) => null() ! h2osfc from previous timestep (inundataion fraction is calculated based on this var)
     real(r8), pointer :: supercool      (:,:) => null() ! supercooled liquid water in soil (kg/m2)
-    real(r8), pointer :: smp            (:,:) => null() ! frozen water potential - RPF maybe should use a differenct variable name?
+    real(r8), pointer :: smp_i          (:,:) => null() ! frozen water potential - RPF maybe should use a differenct variable name?
   contains
     procedure, public :: Init    => col_ws_init
     procedure, public :: Restart => col_ws_restart
@@ -1414,7 +1414,8 @@ contains
     allocate(this%h2osfc             (begc:endc))                     ; this%h2osfc             (:)   = spval
     allocate(this%h2osfc_p           (begc:endc))                     ; this%h2osfc_p           (:)   = spval
     allocate(this%supercool          (begc:endc, 1:nlevgrnd))         ; this%supercool          (:,:) = spval
-    allocate(this%smp                (begc:endc, 1:nlevgrnd))         ; this%smp                (:,:) = spval ! RPF - var name?
+    ! RPF NOTE: i think this means that supercooling is only tracked in soil layers, not snow layers
+    allocate(this%smp_i              (begc:endc, 1:nlevgrnd))         ; this%smp_i              (:,:) = spval 
     allocate(this%h2ocan             (begc:endc))                     ; this%h2ocan             (:)   = spval
     allocate(this%wslake_col         (begc:endc))                     ; this%wslake_col         (:)   = spval
     allocate(this%total_plant_stored_h2o(begc:endc))                  ; this%total_plant_stored_h2o(:)= spval  
@@ -1557,10 +1558,10 @@ contains
           avgflag='A', long_name='supercooled soil water', &
           ptr_col=this%supercool, default='inactive')
    
-    this%smp(begc:endc, 1:nlevgrnd) = spval
-      call hist_addfld2d (fname='SMP', units='mm?', &
+    this%smp_i(begc:endc, 1:nlevgrnd) = spval
+      call hist_addfld2d (fname='SMP_I', units='mm?', &
           avgflag='A', long_name='frozen water potential', &
-          ptr_col=this%smp, default='inactive')
+          ptr_col=this%smp_i, default='inactive')
 
     this%h2osoi_vol(begc:endc,:) = spval
      call hist_addfld2d (fname='H2OSOI',  units='mm3/mm3', type2d='levgrnd', &
@@ -1883,8 +1884,8 @@ contains
              this%h2osoi_ice(c,j) = 0._r8
              this%h2osoi_liq(c,j) = col_pp%dz(c,j)*denh2o*this%h2osoi_vol(c,j)
           endif
-          this%supercool(c,j) = 0._r8 ! could be move to logic above, but seems okay to calculat eon first time step
-          this%smp(c,j) = -9999._r8 ! placeholder default. probably there are better values to use?
+          this%supercool(c,j) = 0._r8
+          this%smp_i(c,j) = 0._r8
          
        end do
 
@@ -1945,7 +1946,6 @@ contains
        this%h2osfc(bounds%begc:bounds%endc) = 0.0_r8
     end if
 
-    ! DEBUG
     call restartvar(ncid=ncid, flag=flag, varname='H2OSFC_P', xtype=ncd_double,  &
          dim1name='column', &
          long_name='surface water', units='kg/m2', &
@@ -2098,10 +2098,13 @@ contains
       this%supercool(bounds%begc:bounds%endc,:) = 0.0_r8
     end if
 
-    call restartvar(ncid=ncid, flag=flag, varname='SMP', xtype=ncd_double,&
+    call restartvar(ncid=ncid, flag=flag, varname='SMP_I', xtype=ncd_double,&
          dim1name='column', dim2name='levtot', switchdim=.true., &
          long_name='frozen water potential', units='mm', &
-         interpinic_flag='interp', readvar=readvar, data=this%smp)
+         interpinic_flag='interp', readvar=readvar, data=this%smp_i)
+     if (flag == 'read' .and. .not. readvar) then
+       this%smp_i(bounds%begc:bounds%endc,:) = 0.0_r8
+     end if
 
     if (use_cn) then
        call restartvar(ncid=ncid, flag=flag, varname='wf', xtype=ncd_double,  &

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -152,7 +152,7 @@ module ColumnDataType
     real(r8), pointer :: frac_sno_eff       (:)   => null() ! fraction of ground covered by snow (0 to 1)
     real(r8), pointer :: frac_iceold        (:,:) => null() ! fraction of ice relative to the tot water (-nlevsno+1:nlevgrnd)
     real(r8), pointer :: frac_h2osfc        (:)   => null() ! fractional area with surface water greater than zero
-    real(r8), pointer :: frac_h2osfc_act    (:)   => null() ! actural fractional area with surface water greater than zero
+    real(r8), pointer :: frac_h2osfc_act    (:)   => null() ! actual fractional area with surface water greater than zero
     real(r8), pointer :: wf                 (:)   => null() ! soil water as frac. of whc for top 0.05 m (0-1)
     real(r8), pointer :: wf2                (:)   => null() ! soil water as frac. of whc for top 0.17 m (0-1)
     real(r8), pointer :: finundated         (:)   => null() ! fraction of column inundated, for bgc caclulation (0-1)
@@ -1656,6 +1656,9 @@ contains
          ptr_col=this%frac_h2osfc)
     
     this%frac_h2osfc_act(begc:endc) = spval
+    call hist_addfld1d (fname='FH2OSFC_ACT', units='1', &
+         avgflag='A', long_name='fraction of ground covered by surface water, ignoring snow cover', &
+         ptr_col=this%frac_h2osfc_act)
          
     if (use_cn) then
        this%wf(begc:endc) = spval
@@ -2062,6 +2065,14 @@ contains
          interpinic_flag='interp', readvar=readvar, data=this%frac_h2osfc)
     if (flag == 'read' .and. .not. readvar) then
        this%frac_h2osfc(bounds%begc:bounds%endc) = 0.0_r8
+    end if
+
+    call restartvar(ncid=ncid, flag=flag, varname='FH2OSFC_ACT', xtype=ncd_double,  &
+         dim1name='column',&
+         long_name='fraction of ground covered by h2osfc (0 to 1), ignoring snow cover', units='', &
+         interpinic_flag='interp', readvar=readvar, data=this%frac_h2osfc_act)
+    if (flag == 'read' .and. .not. readvar) then
+       this%frac_h2osfc_act(bounds%begc:bounds%endc) = 0.0_r8
     end if
 
     if (use_cn) then

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -442,7 +442,8 @@ module ColumnDataType
     real(r8), pointer :: xmf                     (:)   => null() ! total latent heat of phase change of ground water
     real(r8), pointer :: xmf_h2osfc              (:)   => null() ! latent heat of phase change of surface water
     integer , pointer :: imelt                   (:,:) => null() ! flag for melting (=1), freezing (=2), Not=0 (-nlevsno+1:nlevgrnd)
-    ! for coupling with pflotran
+    real(r8), pointer :: tinc                    (:,:) => null() ! phase-change temperature increment tfrz - t_soisno (K) (-nlevsno+1:nlevgrnd)
+    ! for couplig with pflotran
     real(r8), pointer :: eflx_soil_grnd          (:)   => null() ! integrated soil ground heat flux (W/m2)  [+ = into ground]
     real(r8), pointer :: eflx_rnet_soil          (:)   => null() ! soil net (sw+lw) radiation flux (W/m2) [+ = into soil]
     real(r8), pointer :: eflx_fgr0_soil          (:)   => null() ! soil-air heat flux (W/m2) [+ = into soil]

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -1,4 +1,4 @@
-   module ColumnDataType
+module ColumnDataType
 
   !-----------------------------------------------------------------------
   ! !DESCRIPTION:
@@ -36,8 +36,7 @@
   use soilorder_varcon, only : smax, ks_sorption
   use elm_time_manager, only : is_restart, get_nstep
   use elm_time_manager, only : is_first_step, get_step_size, is_first_restart_step
-  use landunit_varcon , only : istice, istwet, istsoil, istdlak, istcrop, istice_mec
-  use landunit_varcon , only : ilowcenpoly, iflatcenpoly, ihighcenpoly
+  use landunit_varcon , only : istice, istwet, istsoil, istdlak, istcrop, istice_mec, istlowcenpoly, isthighcenpoly
   use column_varcon   , only : icol_road_perv, icol_road_imperv, icol_roof, icol_sunwall, icol_shadewall
   use histFileMod     , only : hist_addfld1d, hist_addfld2d, no_snow_normal
   use histFileMod     , only : hist_addfld_decomp
@@ -152,7 +151,7 @@
     real(r8), pointer :: frac_sno_eff       (:)   => null() ! fraction of ground covered by snow (0 to 1)
     real(r8), pointer :: frac_iceold        (:,:) => null() ! fraction of ice relative to the tot water (-nlevsno+1:nlevgrnd)
     real(r8), pointer :: frac_h2osfc        (:)   => null() ! fractional area with surface water greater than zero
-    real(r8), pointer :: frac_h2osfc_act    (:)   => null() ! actual fractional area with surface water greater than zero
+    real(r8), pointer :: frac_h2osfc_act    (:)   => null() ! actural fractional area with surface water greater than zero
     real(r8), pointer :: wf                 (:)   => null() ! soil water as frac. of whc for top 0.05 m (0-1)
     real(r8), pointer :: wf2                (:)   => null() ! soil water as frac. of whc for top 0.17 m (0-1)
     real(r8), pointer :: finundated         (:)   => null() ! fraction of column inundated, for bgc caclulation (0-1)
@@ -181,7 +180,7 @@
     real(r8), pointer :: frac_melted    (:,:) => null() ! fraction of layer that has ever thawed (for tracking excess ice removal) (0 to 1)
     real(r8), pointer :: h2osfc_p         (:) => null() ! h2osfc from previous timestep (inundataion fraction is calculated based on this var)
     real(r8), pointer :: supercool      (:,:) => null() ! supercooled liquid water in soil (kg/m2)
-    real(r8), pointer :: smp_i          (:,:) => null() ! frozen water potential - RPF maybe should use a differenct variable name?
+    real(r8), pointer :: smp_i          (:,:) => null() ! frozen water potential
   contains
     procedure, public :: Init    => col_ws_init
     procedure, public :: Restart => col_ws_restart
@@ -1412,10 +1411,6 @@ contains
     allocate(this%h2osoi_ice         (begc:endc,-nlevsno+1:nlevgrnd)) ; this%h2osoi_ice         (:,:) = spval
     allocate(this%h2osoi_vol         (begc:endc, 1:nlevgrnd))         ; this%h2osoi_vol         (:,:) = spval
     allocate(this%h2osfc             (begc:endc))                     ; this%h2osfc             (:)   = spval
-    allocate(this%h2osfc_p           (begc:endc))                     ; this%h2osfc_p           (:)   = spval
-    allocate(this%supercool          (begc:endc, 1:nlevgrnd))         ; this%supercool          (:,:) = spval
-    ! RPF NOTE: i think this means that supercooling is only tracked in soil layers, not snow layers
-    allocate(this%smp_i              (begc:endc, 1:nlevgrnd))         ; this%smp_i              (:,:) = spval 
     allocate(this%h2ocan             (begc:endc))                     ; this%h2ocan             (:)   = spval
     allocate(this%wslake_col         (begc:endc))                     ; this%wslake_col         (:)   = spval
     allocate(this%total_plant_stored_h2o(begc:endc))                  ; this%total_plant_stored_h2o(:)= spval  
@@ -1554,12 +1549,12 @@ contains
            ptr_col=this%h2osfc_p)
 
     this%supercool(begc:endc, 1:nlevgrnd) = spval
-      call hist_addfld2d (fname='SUPERCOOL', units='mm', &
+      call hist_addfld2d (fname='SUPERCOOL', units='mm', type2d='levgrnd', &
           avgflag='A', long_name='supercooled soil water', &
           ptr_col=this%supercool, default='inactive')
    
     this%smp_i(begc:endc, 1:nlevgrnd) = spval
-      call hist_addfld2d (fname='SMP_I', units='mm?', &
+      call hist_addfld2d (fname='SMP_I', units='mm?', type2d='levgrnd', &
           avgflag='A', long_name='frozen water potential', &
           ptr_col=this%smp_i, default='inactive')
 
@@ -1669,9 +1664,6 @@ contains
          ptr_col=this%frac_h2osfc)
     
     this%frac_h2osfc_act(begc:endc) = spval
-    call hist_addfld1d (fname='FH2OSFC_ACT', units='1', &
-         avgflag='A', long_name='fraction of ground covered by surface water, ignoring snow cover', &
-         ptr_col=this%frac_h2osfc_act)
          
     if (use_cn) then
        this%wf(begc:endc) = spval
@@ -1715,7 +1707,6 @@ contains
        this%wf2(c)                    = spval
        this%total_plant_stored_h2o(c) = 0._r8
        this%h2osfc(c)                 = 0._r8
-       this%h2osfc_p(c)               = 0._r8
        this%h2ocan(c)                 = 0._r8
        this%frac_h2osfc(c)            = 0._r8
        this%frac_h2osfc_act(c)        = 0._r8
@@ -1884,31 +1875,14 @@ contains
              this%h2osoi_ice(c,j) = 0._r8
              this%h2osoi_liq(c,j) = col_pp%dz(c,j)*denh2o*this%h2osoi_vol(c,j)
           endif
-          this%supercool(c,j) = 0._r8
-          this%smp_i(c,j) = 0._r8
-         
        end do
 
        this%h2osoi_liq_old(c,:) = this%h2osoi_liq(c,:)
        this%h2osoi_ice_old(c,:) = this%h2osoi_ice(c,:)
-       if (use_polygonal_tundra .and. lun_pp%ispolygon(l)) then
+       if (use_polygonal_tundra) then
          this%excess_ice(c,:) = 0.36_r8
          this%iwp_subsidence(c) = 0._r8
          this%frac_melted(c,:)  = 0._r8
-         ! set initial microtopographic parameters
-         if (lun_pp%polygontype(l) .eq. ilowcenpoly) then
-            this%iwp_microrel(c) = 0.4_r8
-            this%iwp_exclvol(c) = 0.2_r8
-            this%iwp_ddep(c) = 0.15_r8
-         else if (lun_pp%polygontype(l) .eq. iflatcenpoly) then
-            this%iwp_microrel(c) = 0.1_r8
-            this%iwp_exclvol(c) = 0.05_r8
-            this%iwp_ddep(c) = 0.01_r8
-         else if (lun_pp%polygontype(l) .eq. ihighcenpoly) then
-            this%iwp_microrel(c) = 0.4_r8
-            this%iwp_exclvol(c) = 0.2_r8
-            this%iwp_ddep(c) = 0.05_r8
-         endif
        end if
     end do
 
@@ -1944,14 +1918,6 @@ contains
          interpinic_flag='interp', readvar=readvar, data=this%h2osfc)
     if (flag=='read' .and. .not. readvar) then
        this%h2osfc(bounds%begc:bounds%endc) = 0.0_r8
-    end if
-
-    call restartvar(ncid=ncid, flag=flag, varname='H2OSFC_P', xtype=ncd_double,  &
-         dim1name='column', &
-         long_name='surface water', units='kg/m2', &
-         interpinic_flag='interp', readvar=readvar, data=this%h2osfc_p)
-    if (flag=='read' .and. .not. readvar) then
-       this%h2osfc_p(bounds%begc:bounds%endc) = 0.0_r8
     end if
 
     if(do_budgets) then 
@@ -2091,7 +2057,7 @@ contains
     end if
 
     call restartvar(ncid=ncid, flag=flag, varname='SUPERCOOL', xtype=ncd_double, &
-         dim1name='column', dim2name='levtot', switchdim=.true., &
+         dim1name='column', dim2name='levgrnd', switchdim=.true., &
          long_name='supercooled soil water', units='mm', &
          interpinic_flag='interp', readvar=readvar, data=this%supercool)
     if (flag == 'read' .and. .not. readvar) then
@@ -2099,7 +2065,7 @@ contains
     end if
 
     call restartvar(ncid=ncid, flag=flag, varname='SMP_I', xtype=ncd_double,&
-         dim1name='column', dim2name='levtot', switchdim=.true., &
+         dim1name='column', dim2name='levgrnd', switchdim=.true., &
          long_name='frozen water potential', units='mm', &
          interpinic_flag='interp', readvar=readvar, data=this%smp_i)
      if (flag == 'read' .and. .not. readvar) then

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -179,8 +179,9 @@ module ColumnDataType
     real(r8), pointer :: iwp_subsidence   (:) => null() ! ice wedge polygon ground subsidence (m)
     real(r8), pointer :: excess_ice     (:,:) => null() ! excess ground ice in column (1:nlevgrnd) (0 to 1)
     real(r8), pointer :: frac_melted    (:,:) => null() ! fraction of layer that has ever thawed (for tracking excess ice removal) (0 to 1)
-    real(r8), pointer :: h2osfc_p         (:) => null() !!! DEBUG
-
+    real(r8), pointer :: h2osfc_p         (:) => null() ! h2osfc from previous timestep (inundataion fraction is calculated based on this var)
+    real(r8), pointer :: supercool      (:,:) => null() ! supercooled liquid water in soil (kg/m2)
+    real(r8), pointer :: smp            (:,:) => null() ! frozen water potential - RPF maybe should use a differenct variable name?
   contains
     procedure, public :: Init    => col_ws_init
     procedure, public :: Restart => col_ws_restart
@@ -1411,8 +1412,9 @@ contains
     allocate(this%h2osoi_ice         (begc:endc,-nlevsno+1:nlevgrnd)) ; this%h2osoi_ice         (:,:) = spval
     allocate(this%h2osoi_vol         (begc:endc, 1:nlevgrnd))         ; this%h2osoi_vol         (:,:) = spval
     allocate(this%h2osfc             (begc:endc))                     ; this%h2osfc             (:)   = spval
-    ! DEBUG
     allocate(this%h2osfc_p           (begc:endc))                     ; this%h2osfc_p           (:)   = spval
+    allocate(this%supercool          (begc:endc, 1:nlevgrnd))         ; this%supercool          (:,:) = spval
+    allocate(this%smp                (begc:endc, 1:nlevgrnd))         ; this%smp                (:,:) = spval ! RPF - var name?
     allocate(this%h2ocan             (begc:endc))                     ; this%h2ocan             (:)   = spval
     allocate(this%wslake_col         (begc:endc))                     ; this%wslake_col         (:)   = spval
     allocate(this%total_plant_stored_h2o(begc:endc))                  ; this%total_plant_stored_h2o(:)= spval  
@@ -1545,10 +1547,20 @@ contains
           avgflag='A', long_name='surface water depth', &
            ptr_col=this%h2osfc)
 
-    this%h2osfc(begc:endc) = spval
+    this%h2osfc_p(begc:endc) = spval
      call hist_addfld1d (fname='H2OSFC_P', units = 'mm',  &
           avgflag='A', long_name='surface water depth previous time step', &
            ptr_col=this%h2osfc_p)
+
+    this%supercool(begc:endc, 1:nlevgrnd) = spval
+      call hist_addfld2d (fname='SUPERCOOL', units='mm', &
+          avgflag='A', long_name='supercooled soil water', &
+          ptr_col=this%supercool, default='inactive')
+   
+    this%smp(begc:endc, 1:nlevgrnd) = spval
+      call hist_addfld2d (fname='SMP', units='mm?', &
+          avgflag='A', long_name='frozen water potential', &
+          ptr_col=this%smp, default='inactive')
 
     this%h2osoi_vol(begc:endc,:) = spval
      call hist_addfld2d (fname='H2OSOI',  units='mm3/mm3', type2d='levgrnd', &
@@ -1702,7 +1714,7 @@ contains
        this%wf2(c)                    = spval
        this%total_plant_stored_h2o(c) = 0._r8
        this%h2osfc(c)                 = 0._r8
-       this%h2osfc_p(c)               = 0._r8 ! DEBUG
+       this%h2osfc_p(c)               = 0._r8
        this%h2ocan(c)                 = 0._r8
        this%frac_h2osfc(c)            = 0._r8
        this%frac_h2osfc_act(c)        = 0._r8
@@ -1871,6 +1883,9 @@ contains
              this%h2osoi_ice(c,j) = 0._r8
              this%h2osoi_liq(c,j) = col_pp%dz(c,j)*denh2o*this%h2osoi_vol(c,j)
           endif
+          this%supercool(c,j) = 0._r8 ! could be move to logic above, but seems okay to calculat eon first time step
+          this%smp(c,j) = -9999._r8 ! placeholder default. probably there are better values to use?
+         
        end do
 
        this%h2osoi_liq_old(c,:) = this%h2osoi_liq(c,:)
@@ -2074,6 +2089,19 @@ contains
     if (flag == 'read' .and. .not. readvar) then
        this%frac_h2osfc_act(bounds%begc:bounds%endc) = 0.0_r8
     end if
+
+    call restartvar(ncid=ncid, flag=flag, varname='SUPERCOOL', xtype=ncd_double, &
+         dim1name='column', dim2name='levtot', switchdim=.true., &
+         long_name='supercooled soil water', units='mm', &
+         interpinic_flag='interp', readvar=readvar, data=this%supercool)
+    if (flag == 'read' .and. .not. readvar) then
+      this%supercool(bounds%begc:bounds%endc,:) = 0.0_r8
+    end if
+
+    call restartvar(ncid=ncid, flag=flag, varname='SMP', xtype=ncd_double,&
+         dim1name='column', dim2name='levtot', switchdim=.true., &
+         long_name='frozen water potential', units='mm', &
+         interpinic_flag='interp', readvar=readvar, data=this%smp)
 
     if (use_cn) then
        call restartvar(ncid=ncid, flag=flag, varname='wf', xtype=ncd_double,  &

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -36,7 +36,8 @@ module ColumnDataType
   use soilorder_varcon, only : smax, ks_sorption
   use elm_time_manager, only : is_restart, get_nstep
   use elm_time_manager, only : is_first_step, get_step_size, is_first_restart_step
-  use landunit_varcon , only : istice, istwet, istsoil, istdlak, istcrop, istice_mec, istlowcenpoly, isthighcenpoly
+  use landunit_varcon , only : istice, istwet, istsoil, istdlak, istcrop, istice_mec
+  use landunit_varcon , only : ilowcenpoly, iflatcenpoly, ihighcenpoly
   use column_varcon   , only : icol_road_perv, icol_road_imperv, icol_roof, icol_sunwall, icol_shadewall
   use histFileMod     , only : hist_addfld1d, hist_addfld2d, no_snow_normal
   use histFileMod     , only : hist_addfld_decomp
@@ -1871,10 +1872,24 @@ contains
 
        this%h2osoi_liq_old(c,:) = this%h2osoi_liq(c,:)
        this%h2osoi_ice_old(c,:) = this%h2osoi_ice(c,:)
-       if (use_polygonal_tundra) then
+       if (use_polygonal_tundra .and. lun_pp%ispolygon(l)) then
          this%excess_ice(c,:) = 0.36_r8
          this%iwp_subsidence(c) = 0._r8
          this%frac_melted(c,:)  = 0._r8
+         ! set initial microtopographic parameters
+         if (lun_pp%polygontype(l) .eq. ilowcenpoly) then
+            this%iwp_microrel(c) = 0.4_r8
+            this%iwp_exclvol(c) = 0.2_r8
+            this%iwp_ddep(c) = 0.15_r8
+         else if (lun_pp%polygontype(l) .eq. iflatcenpoly) then
+            this%iwp_microrel(c) = 0.1_r8
+            this%iwp_exclvol(c) = 0.05_r8
+            this%iwp_ddep(c) = 0.01_r8
+         else if (lun_pp%polygontype(l) .eq. ihighcenpoly) then
+            this%iwp_microrel(c) = 0.4_r8
+            this%iwp_exclvol(c) = 0.2_r8
+            this%iwp_ddep(c) = 0.05_r8
+         endif
        end if
     end do
 

--- a/components/elm/src/main/elm_varctl.F90
+++ b/components/elm/src/main/elm_varctl.F90
@@ -416,7 +416,8 @@ module elm_varctl
   ! NGEE Arctic parameterizations
   !----------------------------------------------------------
   logical, public :: use_polygonal_tundra = .false.
-  logical, public :: use_arctic_init     = .false.
+  logical, public :: prohibit_subsidence  = .false.
+  logical, public :: use_arctic_init      = .false.
 
   !----------------------------------------------------------
   ! VSFM switches


### PR DESCRIPTION
This PR adds several soil freezing-related and thermal conductivity variables to ELM
  history output to support analysis of permafrost and frozen soil processes:             
  
  - Soil thermal conductivity (TK) - enables analysis of heat transfer in soil layers     
  - Surface water thermal conductivity (TK_H2OSFC) - tracks thermal properties of surface
  water                                                                                   
  - Supercooling variables (FH2OSFC_ACT) - provides insight into soil water phase changes
  below 0°C                                                                               
  - Optional IWP subsidence control - adds namelist flag to control ice wedge polygon
  subsidence behavior                                                                     
  
  Modified files:                                                                         
  - ColumnDataType.F90 - added new history field definitions
  - SoilTemperatureMod.F90, SoilHydrologyMod.F90, SoilStateType.F90 - implemented variable
   calculations and updates                                                               
  - ActiveLayerMod.F90 - polygon initialization fixes                                     
  - elm_varctl.F90 - added IWP subsidence control flag
  - Namelist files - added new variable definitions and defaults